### PR TITLE
feat: add just via github

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -63,9 +63,12 @@ install_tools:
       extract_cmdline=""
     fi
     if [[ "$repo" != "null" ]]; then
-      gh-release-install "$repo" "$artifact" "$HOME/.local/bin/$binary" --verbose --version "$version" $extract_cmdline
+      echo "Installing $binary@$version from $repo"
+      gh-release-install "$repo" "$artifact" "$HOME/.local/bin/$binary" --version "$version" $extract_cmdline
     fi
   done
+  # Cleanup Just (mpr has it at 1.14)
+  sudo apt remove -y just 1>/dev/null 2>&1 || true
 
 [private]
 updatecli_foreach:

--- a/config/tools.yml
+++ b/config/tools.yml
@@ -1,5 +1,15 @@
 terraform:
   version: 1.5.7
+just:
+  repo: casey/just
+  version: 1.16.0
+  artifact: just-{version}-x86_64-unknown-linux-musl.tar.gz
+  extract: just
+  binary: just
+  updatecli:
+    yamlpath: $.just.version
+    version_pinning: "*"
+    trim_prefix: v
 kubectx:
   repo: ahmetb/kubectx
   version: v0.9.5


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->
MPR has just @ 1.14, whereas github has it at 1.16.0

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- remove just via apt remove after installing tools.
<!-- SQUASH_MERGE_END -->

