### PR TITLE
feat: add lazygit

### DIFF
--- a/config/tools.yml
+++ b/config/tools.yml
@@ -192,3 +192,12 @@ mutagen:
   updatecli:
     yamlpath: $.mutagen.version
     version_pinning: "*"
+lazygit:
+  repo: jesseduffield/lazygit
+  version: v0.40.2
+  artifact:  lazygit_{version}_Linux_x86_64.tar.gz
+  extract: lazygit
+  binary: lazygit
+  updatecli:
+    yamlpath: $.lazygit.version
+    version_pinning: "*"


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->

Add lazygit because it prints out the command log for the 'purposes' of learning the git arcana.
Requires `xdg-utils` to open commits in the browser etc.

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->

<!-- SQUASH_MERGE_END -->

