### PR TITLE
feat: switch to snap yq

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,18 +14,9 @@ Yeah, I know, I'm a terrible person for using `just` because it's yet another th
 
 ## Notes
 
-The keen-eyed will have seen that I'm installing `yq` via python+pip and also `mikefarah/yq` via dpm. I suppose I could install `mikefarah/yq` via snap, and then uninstall it in the same way that I'm uninstalling `just`.
-
-I have `mikefarah/yq` because I can do this `yq eval-all '. as $item ireduce ({}; . *+ $item )' "gh-aliases-old.yml" "gh-aliases-new.yml" > "gh-aliases.yml"` to merge my github aliases files together. I have this exported as a bash-function for me to use in scripts :
-
+- Installs `yq` via snap as part of the `init` recipe; which is subsequently removed by the `install` recipe. Since snap may require systemd to be running the `etc/wsl.conf` in your linux distro has to enable systemd and you have to do the appropriate `wsl --shutdown` dance.
 ```
-function findYQ() {
-  if builtin type -P myq >/dev/null 2>&1; then
-    echo "myq"
-  else
-    echo "yq"
-  fi
-}
-
-export -f findYQ
+[boot]
+systemd=true
 ```
+- Post init+install, you probably want to do a `hash -r` to clear out the bash hash cache otherwise you get `/usr/bin/just not found` errors.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Yeah, I know, I'm a terrible person for using `just` because it's yet another th
 
 ## Notes
 
+- sudo visudo with this for _convenience reasons_. Don't do this on a production class machine.
+```
+%sudo   ALL=(ALL:ALL) NOPASSWD:ALL
+```
 - Installs `yq` via snap as part of the `init` recipe; which is subsequently removed by the `install` recipe. Since snap may require systemd to be running the `etc/wsl.conf` in your linux distro has to enable systemd and you have to do the appropriate `wsl --shutdown` dance.
 ```
 [boot]

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -54,4 +54,4 @@ if [[ "$(lsb_release -si)" != "Ubuntu" ]]; then echo "Try again on Ubuntu"; exit
 
 sudo apt-get install -y apt-transport-https ca-certificates curl gnupg wget
 install_apt_repos
-sudo apt-get install -y just direnv git zoxide jq tidy 
+sudo apt-get install -y just direnv git zoxide jq tidy

--- a/config/tools.yml
+++ b/config/tools.yml
@@ -174,12 +174,11 @@ actionlint:
   updatecli:
     yamlpath: $.actionlint.version
     version_pinning: "*"
-# We install mikefarah/yq as myq since the pip yq is not the same.
 mikefarah-yq:
   repo: mikefarah/yq
   version: v4.40.4
   artifact: yq_linux_amd64
-  binary: myq
+  binary: yq
   updatecli:
     yamlpath: $.mikefarah-yq.version
     version_pinning: "*"


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->
There's no point having the pip version of yq since it's not a direct transient dependency for gh-release-install.

Use the snap version of mikefarah/yq to bootstrap and remove it like we do 'just'

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- use snap variant of yq to bootstrap
- install mikefarah/yq as yq
- add note about snap+systemd
<!-- SQUASH_MERGE_END -->