### PR TITLE
feat!: add language version management

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -4,6 +4,8 @@ TOOL_CONFIG:=justfile_directory() / "config/tools.yml"
 UPDATECLI_TEMPLATE:=justfile_directory() / "config/updatecli.yml"
 LOCAL_CONFIG:= env_var('HOME') / ".config/ubuntu-dpm"
 INSTALLED_VERSIONS:= LOCAL_CONFIG / "installed-versions"
+CURL:="curl -fSsL"
+alias install:=tools
 
 # show recipes
 [private]
@@ -34,10 +36,61 @@ updatecli +args='diff':
   rm -rf "$tmpdir"
 
 # initialise to install tools
-@init: is_ubuntu install_base install_github_cli install_tfenv
+@init: is_ubuntu install_base install_github_cli
 
 # install tooling
-@install: is_ubuntu install_tools
+@tools: is_ubuntu install_tools
+
+# install sdk tooling
+@sdk: is_ubuntu install_sdkman install_nvm install_rvm install_rust install_tfenv
+
+[private]
+install_sdkman:
+  #!/usr/bin/env bash
+  set -eo pipefail
+  {{ CURL }} "https://get.sdkman.io" | bash
+
+  source ~/.sdkman/bin/sdkman-init.sh
+  graal_latest=$(gh release list -R graalvm/graalvm-ce-builds | grep -i Latest | awk '{print $6}')
+  gradle_latest=$(gh release list -R gradle/gradle | grep -i Latest | awk '{print $1}')
+  maven_latest=$(gh release list -R apache/maven | grep -i Latest | awk '{print $1}')
+  jbang_latest=$(gh release list -R jbangdev/jbang | grep -i Latest | awk '{print $1}')
+  graal_v=${graal_latest#"v"}
+  mvn_v=${maven_latest#"v"}
+  gradle_v=${gradle_latest#"v"}
+  jbang_v=${jbang_latest#"v"}
+  echo "GraalVM $graal_v" && sdk install java "$graal_v-graalce" && sdk default java "$graal_v-graalce"
+  echo "Gradle $gradle_v" && sdk install gradle "$gradle_v" && sdk default gradle "$gradle_v"
+  echo "Maven $mvn_v" && sdk install maven "$mvn_v" && sdk default maven "$mvn_v"
+  echo "jbang $jbang_v" && sdk install jbang "$jbang_v" && sdk default jbang "$jbang_v"
+
+[private]
+install_nvm:
+  #!/usr/bin/env bash
+  set -eo pipefail
+
+  nvm_v=$(gh release list -R nvm-sh/nvm | grep -i Latest | awk '{print $1}')
+  {{ CURL }}  "https://raw.githubusercontent.com/nvm-sh/nvm/$nvm_v/install.sh" | bash
+  source ~/.nvm/nvm.sh
+  nvm install --lts && nvm use --lts
+
+[private]
+install_rust:
+  #!/usr/bin/env bash
+  set -eo pipefail
+  {{ CURL }}  --proto '=https' --tlsv1.2 https://sh.rustup.rs | sh -s -- -y
+
+[private]
+install_rvm:
+  #!/usr/bin/env bash
+  set -eo pipefail
+
+  gpg --keyserver keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+  {{ CURL }}  "https://get.rvm.io" | bash -s stable
+  source ~/.rvm/scripts/rvm
+  ruby_latest=$(gh release list -R ruby/ruby | grep -i Latest | awk '{print $1}')
+  ruby_v=${ruby_latest#"v"}
+  echo "Ruby $ruby_v" && rvm install ruby "$ruby_v" && rvm use "$ruby_v"
 
 [private]
 install_tools:
@@ -70,9 +123,6 @@ install_tools:
   }
 
   mkdir -p "{{ LOCAL_CONFIG }}"
-  tf_v=$(cat "{{ TOOL_CONFIG }}" | yq -r ".terraform.version")
-  tfenv install "$tf_v"
-  tfenv use "$tf_v"
 
   declare -A installed
   read_installed
@@ -159,6 +209,9 @@ install_tfenv:
     (cd $HOME && git clone https://github.com/tfutils/tfenv .tfenv)
     ln -s $HOME/.tfenv/bin/* $HOME/.local/bin
   fi
+  tf_v=$(cat "{{ TOOL_CONFIG }}" | yq -r ".terraform.version")
+  $HOME/.tfenv/bin/tfenv install "$tf_v"
+  $HOME/.tfenv/bin/tfenv use "$tf_v"
 
 [private]
 [no-cd]

--- a/Justfile
+++ b/Justfile
@@ -79,6 +79,9 @@ install_rust:
   #!/usr/bin/env bash
   set -eo pipefail
   {{ CURL }}  --proto '=https' --tlsv1.2 https://sh.rustup.rs | sh -s -- -y
+  {{ CURL }} "https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz" | tar xz
+  ./cargo-binstall -y --force cargo-binstall >/dev/null 2>&1
+  rm -f ./cargo-binstall >/dev/null 2>&1
 
 [private]
 install_rvm:

--- a/Justfile
+++ b/Justfile
@@ -42,7 +42,18 @@ updatecli +args='diff':
 @tools: is_ubuntu install_tools
 
 # install sdk tooling
-@sdk: is_ubuntu install_sdkman install_nvm install_rvm install_rust install_tfenv
+@sdk: is_ubuntu install_sdkman install_nvm install_rvm install_rust install_tfenv install_go
+
+# not entirely sure I like this as a chicken & egg situation since goenv must be installed
+# by 'tools' recipe
+[private]
+install_go:
+  #!/usr/bin/env bash
+
+  set -eo pipefail
+  go_v=$(goenv --list-remote | grep -v -e "beta" -e "rc[0-9]*" | sort -rV | head -n 1)
+  goenv --install "$go_v"
+  goenv --use "$go_v"
 
 [private]
 install_sdkman:

--- a/README.md
+++ b/README.md
@@ -8,19 +8,18 @@ It's not intended to be that useful to anyone else, but if you want to use it, y
 
 - `bootstrap.sh` to bootstrap extra apt repos and install some initial tooling
 - `just init`
-- `just install`
+- `just tools` | `just install`
+- `just sdk`
 
 Yeah, I know, I'm a terrible person for using `just` because it's yet another thing you need to install. I'm not sorry.
 
 ## Notes
 
-- sudo visudo with this for _convenience reasons_. Don't do this on a production class machine.
-```
-%sudo   ALL=(ALL:ALL) NOPASSWD:ALL
-```
-- Installs `yq` via snap as part of the `init` recipe; which is subsequently removed by the `install` recipe. Since snap may require systemd to be running the `etc/wsl.conf` in your linux distro has to enable systemd and you have to do the appropriate `wsl --shutdown` dance.
+- `echo "$USER ALL=(ALL:ALL) NOPASSWD:ALL" | sudo tee -a /etc/sudoers` (or into `/etc/sudoers.d/i_hates_security`). This is for _convenience reasons_; it's a terrible idea.
+- Installs `yq` via snap as part of the `init` recipe; which is subsequently removed by the `install` recipe. Since snap may require systemd to be running the `etc/wsl.conf` in your WSL2 linux distro has to enable systemd and you have to do the appropriate `wsl --shutdown` dance. This may already be true if you're building a new machine (as I did in 2023-12; but YMMV).
 ```
 [boot]
 systemd=true
 ```
-- Post init+install, you probably want to do a `hash -r` to clear out the bash hash cache otherwise you get `/usr/bin/just not found` errors.
+- Post init+tools, you probably want to do a `hash -r` to clear out the bash hash cache otherwise you get `/usr/bin/just not found` errors.
+- Keeps a track of the files its installed in `~/.config/ubuntu-dpm/installed-versions` so it doesn't try to install the same version of things repeatedly.

--- a/config/tools.yml
+++ b/config/tools.yml
@@ -200,3 +200,12 @@ lazygit:
   updatecli:
     yamlpath: $.lazygit.version
     version_pinning: "*"
+goenv:
+  repo: ankitcharolia/goenv
+  version: 1.1.7
+  artifact: goenv-linux-amd64.tar.gz
+  extract: goenv
+  binary: goenv
+  updatecli:
+    yamlpath: $.goenv.version
+    version_pinning: "*"


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->

Script the installation of various language version managers and install the 'latest' stable version of each of those languages.
Move `install_tfenv` into the sdk recipe and force the initial version of terraform there rather than in tools to avoid a needless abstraction leak.

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- Add ruby/node/java/rust/go version managers
- Update docs to reflect usage change
- tfenv moved into 'sdk' recipe
<!-- SQUASH_MERGE_END -->

