### PR TITLE
feat: add tofuenv to manage opentofu

### DIFF
--- a/config/tools.yml
+++ b/config/tools.yml
@@ -1,5 +1,7 @@
 terraform:
   version: 1.5.7
+opentofu:
+  version: 1.6.0
 just:
   repo: casey/just
   version: 1.22.1


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->

Opentofu is now GA (1.6.0) and we can use tofuenv to manage the tofu versions. Since they are separate binaries both terraform & opentofu can of course live side-by-side.

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- made 'install_tfenv' more generic
- made sdk recipes public
<!-- SQUASH_MERGE_END -->

