### PR TITLE
feat(go)!: add go-nv/goenv

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -161,6 +161,24 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           just sdk java
+  test_goenv_install:
+    runs-on: ubuntu-latest
+    name: install-goenv
+    outputs:
+      result: ${{ steps.install.outcome || 'failure' }}
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - name: Install Just
+        uses: taiki-e/install-action@00a67321d66e038602baf558d366a594a7019ea2 # v2.33.9
+        with:
+          tool: just@${{ env.JUST_VERSION }}
+      - name: Test Install
+        id: install
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          just sdk goenv install
   test_status:
     name: Assert Tests Passed
     runs-on: ubuntu-latest
@@ -173,6 +191,7 @@ jobs:
       - test_tofuenv_install
       - test_rvm_install
       - test_sdkman_install
+      - test_goenv_install
     steps:
       - name: test status
         id: test_status

--- a/Justfile
+++ b/Justfile
@@ -94,9 +94,11 @@ sdk_install_all: sdk_install_rust sdk_install_nvm sdk_install_java (sdk_install_
 [private]
 sdk_install_go:
   #!/usr/bin/env bash
+  # shellcheck disable=SC2002
 
   set -eo pipefail
-  go_v=$(goenv --list-remote | grep -v -e "beta" -e "rc[0-9]*" | sort -rV | head -n 1)
+  go_v=$(cat "{{ SDK_CONFIG }}" | yq -r ".golang.version")
+  # go_v=$(goenv --list-remote | grep -v -e "beta" -e "rc[0-9]*" | sort -rV | head -n 1)
   goenv --install "$go_v"
   goenv --use "$go_v"
 
@@ -106,6 +108,7 @@ sdk_install_go:
 sdk_install_goenv action="update":
   #!/usr/bin/env bash
   # shellcheck disable=SC2016
+  # shellcheck disable=SC2002
 
   set -eo pipefail
   mkdir -p "{{ LOCAL_BIN }}"
@@ -131,9 +134,7 @@ sdk_install_goenv action="update":
         } >> ~/.bashrc
       fi
     fi
-    # while this warning is certainly true, go-build should only contain version numbers...
-    # shellcheck disable=SC2010
-    go_v=$(ls -1 "{{ GOENV_ROOT }}/plugins/go-build/share/go-build" | grep -v -e "beta" -e "rc" | sort -rV | head -n 1)
+    go_v=$(cat "{{ SDK_CONFIG }}" | yq -r ".golang.version")
     "{{ GOENV_ROOT }}/bin/goenv" install -s "$go_v"
     "{{ GOENV_ROOT }}/bin/goenv" global "$go_v"
     "{{ GOENV_ROOT }}/bin/goenv" versions

--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ echo "$USER ALL=(ALL:ALL) NOPASSWD:ALL" | sudo tee -a /etc/sudoers.d/lenient
 ./bootstrap.sh repos
 # to install some initial tooling
 ./bootstrap.sh baseline
-# Now you will need to know your ghcli token info
 just init
 # If you are one to use the github cli
 # just ghcli
@@ -88,10 +87,12 @@ Various environment variables control behaviour.
 - `DPM_REPO_ADDITIONS_YAML` - can be set to an additional repos yaml path, will be merged base repos.yml
 - `DPM_SDK_YAML` - can be set to your custom sdk yaml path
 - `DPM_SKIP_FZF_PROFILE` - set to any value to skip bashrc shenanigans by `fzf-git`
-- `DPM_SKIP_JAVA_PROFILE` - set to any value to skip profile modifications by sdkman
-- `DPM_SKIP_NVM_PROFILE` - set to any value to skip profile modifications by nvm
-- `DPM_SKIP_RVM_PROFILE` - set to any value to skip profile modifications by rvm
-- `DPM_SKIP_RUST_PROFILE` - set to any value to skip profile modifications by rustup
+- `DPM_SKIP_GO_PROFILE` - set to any value to skip profile modifications by `go-nv/goenv` (via _just sdk goenv_)
+  - if you opt to use `ankitcharolia/goenv` then this always modifies your profile (via _just sdk go_)
+- `DPM_SKIP_JAVA_PROFILE` - set to any value to skip profile modifications by sdkman (via _just sdk java_)
+- `DPM_SKIP_NVM_PROFILE` - set to any value to skip profile modifications by nvm (via _just sdk nvm_)
+- `DPM_SKIP_RVM_PROFILE` - set to any value to skip profile modifications by rvm (via _just sdk rvm_)
+- `DPM_SKIP_RUST_PROFILE` - set to any value to skip profile modifications by rustup (via _just sdk rust_)
 
 > The various YAML files should be self explanatory and control
 >

--- a/config/sdk.yml
+++ b/config/sdk.yml
@@ -15,3 +15,5 @@ rvm:
   ruby: 3.3.1
 nvm:
   version: v0.39.7
+golang:
+  version: 1.22.2

--- a/config/tools.yml
+++ b/config/tools.yml
@@ -122,6 +122,11 @@ lazygit:
   version: v0.41.0
   artifact: lazygit_{version}_Linux_x86_64.tar.gz
   contents: lazygit
+goenv:
+  repo: ankitcharolia/goenv
+  version: 1.1.8
+  artifact: goenv-linux-amd64.tar.gz
+  contents: goenv
 difftastic:
   repo: wilfred/difftastic
   version: 0.57.0

--- a/config/tools.yml
+++ b/config/tools.yml
@@ -122,11 +122,6 @@ lazygit:
   version: v0.41.0
   artifact: lazygit_{version}_Linux_x86_64.tar.gz
   contents: lazygit
-goenv:
-  repo: ankitcharolia/goenv
-  version: 1.1.8
-  artifact: goenv-linux-amd64.tar.gz
-  contents: goenv
 difftastic:
   repo: wilfred/difftastic
   version: 0.57.0

--- a/updatecli.d/sdk-golang.yml
+++ b/updatecli.d/sdk-golang.yml
@@ -1,0 +1,58 @@
+# {{ $scmEnabled := and (env "GITHUB_REPOSITORY_OWNER") (env "GITHUB_REPOSITORY_NAME") }}
+name: "golang"
+
+# {{ if $scmEnabled }}
+actions:
+  pull_request:
+    scmid: github
+    title: 'chore(deps): Bump golang version to {{ source "latest" }}'
+    kind: github/pullrequest
+    spec:
+      labels:
+        - dependencies
+
+scms:
+  github:
+    disabled: false
+    kind: github
+    spec:
+      branch: main
+      owner: '{{ requiredEnv "GITHUB_REPOSITORY_OWNER" }}'
+      repository: '{{ requiredEnv "GITHUB_REPOSITORY_NAME" }}'
+      user: '{{ requiredEnv "UPDATECLI_GITHUB_USER" }}'
+      email: '{{ requiredEnv "UPDATECLI_GITHUB_EMAIL" }}'
+      username: '{{ requiredEnv "UPDATECLI_GITHUB_USER" }}'
+      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+      commitmessage:
+        type: "chore"
+        scope: "deps"
+        title: 'Bump golang to {{ source "latest" }}'
+        hidecredit: true
+# {{ end }}
+
+sources:
+  latest:
+    name: Github release for golang
+    kind: githubrelease
+    spec:
+      owner: golang
+      repository: go
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      versionfilter:
+        kind: regex
+        pattern: "go[0-9]+\\.[0-9]+\\.[0-9]+$"
+    transformers:
+      - trimprefix: go
+
+targets:
+  update_yaml:
+    kind: yaml
+    sourceid: latest
+    name: 'Bump golang version to {{ source "latest" }}'
+    # {{ if $scmEnabled }}
+    scmid: github
+    # {{ end }}
+    spec:
+      files:
+        - ./config/sdk.yml
+      key: $.golang.version


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->
`ankitcharolia/goenv` seems to be a global goenv style tool. Isn't shell instance specific, or even directory specific. It also requires us to have done `just tools` first.

An alternative that is being updated is `go-nv/go-env` which is different. It is possible for both  to potentially live in harmony with each other, so we can install them side by side.

ankitcharolia/goenv becomes what go-nv/go-env thinks is the system go...

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- add 'sdk goenv install' to install goenv & golang
- add 'sdk goenv update' to update go-nv/goenv repo
- remove 'sdk go' from 'sdk all'
- golang version explicitly defined in config/sdk.yml

BREAKING CHANGE: 'sdk all' no longer installs a golang version manager, the user has to make
an explicit choice.
<!-- SQUASH_MERGE_END -->

## Notes

Since go-nv doesn't have the same concept of `--list-remotes` that ankitcharolia does which means we need need to pull changes to the repo to get a new list of versions.

- Not sure how the shimming works with go-nv; probably no impact since it only shims gofmt and go itself.
- go-nv is potentially better than ankitcharolia since it doesn't mess with your bash profile

## Testing

```shell
just sdk goenv install
# do the shell restart dance and check the version/location of go (which should be goenv/shims)
# install a tool of your choice and run it...
go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.58.0
```
