### PR TITLE
feat: add wslu only on Debian WSL

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -140,7 +140,7 @@ action_baseline() {
     sudo apt install -y just
   fi
   pipx install gh-release-install
-  if [[ "$(distro_name)" == "debian" ]]; then
+  if [[ -n "$WSL_DISTRO_NAME" && "$(distro_name)" == "debian" ]]; then
     sudo apt install -y wslu
   fi
   install_docker

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -128,7 +128,7 @@ action_repos() {
   if [[ "$(distro_name)" == "ubuntu" ]]; then
     sudo add-apt-repository -y ppa:git-core/ppa
   fi
-  if [[ -n "$WSL_DISTRO_NAME" && "$(distro_name)" == "debian" ]]; then
+  if [[ -n "$WSL_DISTRO_NAME" ]]; then
     repo_wslutilities
   fi
   sudo apt update
@@ -140,7 +140,7 @@ action_baseline() {
     sudo apt install -y just
   fi
   pipx install gh-release-install
-  if [[ -n "$WSL_DISTRO_NAME" && "$(distro_name)" == "debian" ]]; then
+  if [[ -n "$WSL_DISTRO_NAME" ]]; then
     sudo apt install -y wslu
   fi
   install_docker

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -65,6 +65,12 @@ repo_ghcli() {
   echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list
 }
 
+# wsl utilities
+repo_wslutilities() {
+  download_keyrings https://pkg.wslutiliti.es/public.key  "wslutilities"
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/wslutilities.gpg] https://pkg.wslutiliti.es/debian $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/wslutilities.list
+}
+
 install_vscode() {
   if [[ -z "$WSL_DISTRO_NAME" && -n "${XDG_CURRENT_DESKTOP}" ]]; then
     vscode_deb=$(mktemp --tmpdir vscode.XXXXX.deb)
@@ -122,6 +128,9 @@ action_repos() {
   if [[ "$(distro_name)" == "ubuntu" ]]; then
     sudo add-apt-repository -y ppa:git-core/ppa
   fi
+  if [[ -n "$WSL_DISTRO_NAME" && "$(distro_name)" == "debian" ]]; then
+    repo_wslutilities
+  fi
   sudo apt update
 }
 
@@ -131,6 +140,9 @@ action_baseline() {
     sudo apt install -y just
   fi
   pipx install gh-release-install
+  if [[ "$(distro_name)" == "debian" ]]; then
+    sudo apt install -y wslu
+  fi
   install_docker
   install_vscode
 }


### PR DESCRIPTION
# Motivation
Add [`wslu`](https://github.com/wslutilities/wslu) for opening browsers from other cli (`gh auth`).

Skipped to Ubuntu as the package is already present on there builds.

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- add wslutilities repo and keyring if WSL and Debian
- add wslu package if WSL and Debian 
<!-- SQUASH_MERGE_END -->

