### PR TITLE
feat: add fzf for cli fuzzy finding

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -147,7 +147,7 @@ sdk_install_nvm:
 # Install rustup && cargo-binstall (because rust)
 [private]
 sdk_install_rust:
-  #!/usr/bin/env bash``
+  #!/usr/bin/env bash
   set -eo pipefail
   {{ CURL }}  --proto '=https' --tlsv1.2 https://sh.rustup.rs | sh -s -- -y
   {{ CURL }} "https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz" | tar xz

--- a/config/tools.yml
+++ b/config/tools.yml
@@ -218,4 +218,10 @@ jf:
   contents: jf
   updatecli:
     yamlpath: $.jf.version
-
+fzf:
+  repo: junegunn/fzf
+  version: 0.50.0
+  artifact: fzf-{version}-linux_amd64.tar.gz
+  contents: fzf
+  updatecli:
+    yamlpath: $.fzf.version


### PR DESCRIPTION
# Motivation

Add `fzf` for a cli fuzzy finding, the version in Debian repo is quite far behind.

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- Add fzf to tools.yml
<!-- SQUASH_MERGE_END -->

## Usage

```shell
# .bash_profile

if type fzf &>/dev/null; then
  eval "$(fzf --bash)"
fi
```

## Extending Further

After set-up there's some interesting scripts out there [fzf-git](https://github.com/junegunn/fzf-git.sh):

Add `fzf-tmux` which is required by `fzf-git`.

```shell
curl -L https://raw.githubusercontent.com/junegunn/fzf/master/bin/fzf-tmux -o ~/.local/bin/fzf-tmux
chmod +x ~/.local/bin/fzf-tmux
```

Checkout `fzf-git`:

```shell 
git clone git@github.com:junegunn/fzf-git.sh.git
```

```shell
# .bash_profile

if [ -e "$HOME/code/.../fzf-git.sh/fzf-git.sh" ]; then
  # shellcheck source=/dev/null
  source "$HOME/code/.../fzf-git.sh/fzf-git.sh"
fi
```
