### PR TITLE
feat: cleanup tooling baseline

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,25 @@
+name: shellcheck
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: checkout
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
+      - name: shellcheck
+        uses: reviewdog/action-shellcheck@72365a51bf6476fe952a117c3ff703eb7775e40a # v1.20.0
+        with:
+          reporter: github-pr-review
+          pattern: |
+            bootstrap.sh
+          fail_on_error: true
+          github_token: ${{ secrets.github_token }}

--- a/Justfile
+++ b/Justfile
@@ -255,7 +255,7 @@ install_tools:
 
   yq_wrapper() {
     if ! which yq >/dev/null 2>&1; then
-      gh-release-install "mikefarah/yq" "yq_linux_amd64" "$HOME/.local/bin/yq"
+      gh-release-install "mikefarah/yq" "yq_linux_amd64" "$HOME/.local/bin/yq" --version v4.43.1
       $HOME/.local/bin/yq "$@"
     else
       yq "$@"

--- a/Justfile
+++ b/Justfile
@@ -253,15 +253,10 @@ install_tools:
   # and then do the wsl --shutdown restart dance.
   set -eo pipefail
 
-  yq_init() {
-    if ! which yq >/dev/null 2>&1; then
-      docker pull mikefarah/yq
-    fi
-  }
-
   yq_wrapper() {
     if ! which yq >/dev/null 2>&1; then
-      docker run --rm -i -v "${PWD}":/workdir mikefarah/yq "$@"
+      gh-release-install "mikefarah/yq" "yq_linux_amd64" "$HOME/.local/bin/yq"
+      $HOME/.local/bin/yq "$@"
     else
       yq "$@"
     fi
@@ -285,7 +280,6 @@ install_tools:
 
   mkdir -p "{{ LOCAL_CONFIG }}"
   mkdir -p "{{ LOCAL_BIN }}"
-  yq_init
 
   declare -A installed
   read_installed

--- a/Justfile
+++ b/Justfile
@@ -149,7 +149,7 @@ sdk_install_nvm:
 sdk_install_rust:
   #!/usr/bin/env bash
   set -eo pipefail
-  {{ CURL }}  --proto '=https' --tlsv1.2 https://sh.rustup.rs | sh -s -- -y
+  {{ CURL }}  --proto '=https' --tlsv1.2 https://sh.rustup.rs | sh -s -- -y --no-modify-path
   {{ CURL }} "https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz" | tar xz
   ./cargo-binstall -y --force cargo-binstall >/dev/null 2>&1
   rm -f ./cargo-binstall >/dev/null 2>&1

--- a/README.md
+++ b/README.md
@@ -4,24 +4,27 @@ Tries to be a thing that can 'manage' applications on an ubuntu machine. The why
 
 It's not intended to be that useful to anyone else, but if you want to use it, you can (but don't hold me accountable; you're good enough to want to use this, you're good enough to understand bash scripts).
 
-## TLDR;
+## TLDR
 
-> If you want to use your own tools.yml file then `export DPM_TOOLS_YAML=/path/to/my/tools.yml` before running `just tools`.
+> All in all from a `wsl --install Debian|Ubuntu` or similar you should have everything ready toolwise in ~10 minutes (there's a lot of network traffic).
+>
+> - If you want to use your own tools.yml file then `export DPM_TOOLS_YAML=/path/to/my/tools.yml` before running `just tools`.
+> - You may need to do a `wsl.exe --shutdown` dance after `bootstrap.sh baseline`. We will try to modify /etc/wsl.conf if it doesn't already exist to enable systemd (because docker wants it) and we do some shenanigans to binfmt to stop it from making wslview sad.
 
 - `bootstrap.sh repos` to install the apt repos we need
 - `bootstrap.sh baseline` to install some initial tooling
 - `just init`
 - `just tools` | `just install`
-- `just sdk`
-
-Yeah, I know, I'm a terrible person for using `just` because it's yet another thing you need to install. I'm not sorry.
+- `just sdk all`
 
 ## Notes
 
 - I also do this before I start
+
 ```bash
 echo "$USER ALL=(ALL:ALL) NOPASSWD:ALL" | sudo tee -a /etc/sudoers.d/lenient
-sudo apt update && sudo apt -y install vim nfs-common unison jq direnv zip unzip net-tools git
+sudo apt update && sudo apt -y install vim nfs-common unison jq direnv zip unzip net-tools git rcm
+# This stuff is useful, but entirely optional.
 if [[ -z "$WSL_DISTRO_NAME" ]]; then
   sudo apt -y install openssh-server
 fi
@@ -31,10 +34,12 @@ fi
 sudo update-alternatives --set editor /usr/bin/vim.basic
 sudo apt -y autoremove
 if [ ! -f ~/.ssh/id_ed25519 ]; then
-  ssh-keygen -t ed25519 -a 32
+  ssh-keygen -t ed25519 -a 96
 fi
 ```
+
 - `echo "$USER ALL=(ALL:ALL) NOPASSWD:ALL" | sudo tee -a /etc/sudoers.d/lenient` is a terrible idea.
-- If `yq` is not installed then we use it via docker as part of the tool installation; afterwards it'll exist.
+- `just` is installed during `bootstrap.sh baseline` via gh-release-install; it gets ovewritten again when you do `just tools`
+- `yq` will be installed during `just tools` if it doesn't already exist (and promptly overwritten by the tool installation); previously we used docker, but people might not want docker all the time every time.
 - Post init+tools, you probably want to do a `hash -r` to clear out the bash hash cache otherwise you get `/usr/bin/just not found` errors.
 - Keeps a track of the files its installed in `~/.config/ubuntu-dpm/installed-versions` so it doesn't try to install the same version of things repeatedly.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -142,6 +142,16 @@ action_baseline() {
   pipx install gh-release-install
   if [[ -n "$WSL_DISTRO_NAME" ]]; then
     sudo apt install -y wslu
+    # Having wslview in debian & ubuntu can cause trouble with binfmt
+    # stop systemctl from starting binfmt.
+    # c.f. : https://github.com/microsoft/WSL/issues/8843
+    # https://github.com/microsoft/WSL/issues/8986
+    sudo systemctl mask systemd-binfmt.service
+    # Could also 'force' it to work.
+    # echo ":WSLInterop:M::MZ::/init:PF" | sudo tee /usr/lib/binfmt.d/WSLInterop.conf
+    # sudo apt install binfmt-support
+    # sudo systemctl restart binfmt-support
+    sudo systemctl restart systemd-binfmt
   fi
   install_docker
   install_vscode

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -9,6 +9,7 @@ PRE_REQ_TOOLS="apt-transport-https ca-certificates curl gnupg wget software-prop
 DOCKER_TOOL_LIST="docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin"
 BASELINE_TOOL_LIST="vim nfs-common unison direnv git zoxide jq tidy kubectl helm gh jq pipx trivy net-tools zip unzip"
 
+# shellcheck disable=SC2089
 DOCKER_USE_WINCREDS='
 {
   "credsStore": "wincred.exe"
@@ -30,6 +31,7 @@ download_keyrings(){
 # docker
 repo_docker() {
   download_keyrings "https://download.docker.com/linux/$(distro_name)/gpg" "docker"
+  # shellcheck disable=SC1091
   echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker.gpg] https://download.docker.com/linux/$(distro_name) \
     $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
     sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
@@ -76,9 +78,10 @@ install_vscode() {
 install_docker() {
   if [[ -z "$SKIP_DOCKER" ]]
   then
+    # shellcheck disable=SC2086
     sudo apt -y install $DOCKER_TOOL_LIST
     sudo groupadd docker || true
-    sudo usermod -aG docker $USER
+    sudo usermod -aG docker "$USER"
     # If we're on windows then we can use the docker credential helper
     if [[ -n "$WSL_DISTRO_NAME" ]]; then
       wincred_version=$(curl -fsSL -o /dev/null -w "%{url_effective}" https://github.com/docker/docker-credential-helpers/releases/latest | xargs basename)
@@ -87,9 +90,9 @@ install_docker() {
       curl -fSsL -o ~/.local/bin/docker-credential-wincred.exe \
         "https://github.com/docker/docker-credential-helpers/releases/download/${wincred_version}/docker-credential-wincred-${wincred_version}.windows-$(dpkg --print-architecture).exe"
       chmod +x ~/.local/bin/docker-credential-wincred.exe
-      echo $DOCKER_USE_WINCREDS > ~/.docker/config.json
+      echo "$DOCKER_USE_WINCREDS" > ~/.docker/config.json
       if [[ ! -f /etc/wsl.conf ]]; then
-        sudo echo $WSL_CONF > /etc/wsl.conf
+        echo "$WSL_CONF" | sudo tee /etc/wsl.conf
         echo ">>> /etc/wsl.conf modified, you need to restart WSL"
       fi
     fi
@@ -112,6 +115,7 @@ EOF
 }
 
 action_repos() {
+  # shellcheck disable=SC2086
   sudo apt install -y $PRE_REQ_TOOLS
   repo_kubectl
   repo_helm
@@ -121,18 +125,19 @@ action_repos() {
   if [[ "$(distro_name)" == "ubuntu" ]]; then
     sudo add-apt-repository -y ppa:git-core/ppa
   fi
-  if [[ -n "$WSL_DISTRO_NAME" ]]; then
+  if [[ -n "$WSL_DISTRO_NAME" && "$(distro_name)" == "debian" ]]; then
     repo_wslutilities
   fi
   sudo apt update
 }
 
 action_baseline() {
+  # shellcheck disable=SC2086
   sudo apt install -y $BASELINE_TOOL_LIST
   pipx install gh-release-install
     if ! which just >/dev/null 2>&1; then
     # Oneshot install that we know works for us.
-    $HOME/.local/bin/gh-release-install "casey/just" "just-1.25.2-x86_64-unknown-linux-musl.tar.gz" "$HOME/.local/bin/just" --extract just
+    "$HOME/.local/bin/gh-release-install" "casey/just" "just-1.25.2-x86_64-unknown-linux-musl.tar.gz" "$HOME/.local/bin/just" --extract just
   fi
   install_docker
   install_vscode
@@ -147,18 +152,19 @@ action_baseline() {
     # echo ":WSLInterop:M::MZ::/init:PF" | sudo tee /usr/lib/binfmt.d/WSLInterop.conf
     # sudo apt install binfmt-support
     # sudo systemctl restart binfmt-support
-    sudo systemctl restart systemd-binfmt || true
-    echo ">>> You might need to restart WSL for the changes to take effect"
+    # sudo systemctl restart systemd-binfmt || true
+    echo ">>> You might need to restart WSL for binfmt changes to take effect"
   fi
 }
 
 distro_name() {
   if [[ -e "/etc/os-release" ]]; then
+    # shellcheck disable=SC1091
     release=$(. /etc/os-release && echo "$ID" | tr '[:upper:]' '[:lower:]')
   else
     release=$(lsb_release -si | tr '[:upper:]' '[:lower:]') || true
   fi
-  echo $release
+  echo "$release"
 }
 
 if [[ "$(uname -o | tr '[:upper:]' '[:lower:]')" == "msys" ]]; then echo "Try again on WSL2+Ubuntu"; exit 1; fi


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->

If SKIP_DOCKER is set then you can _never_ run `just tools`; so the requirement is to remove the use of docker to run `yq`

Since we are doing that, then we should reduce complexity by install oneshot tools like `just` in bootstrap.sh rather than adding the prebuilt repo unnecessarily.

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- remove prebuilt_mpr as a repo
- install 'just' via gh-release-install
- install 'yq' in justfile via gh-release-install
- add systemctl mask or binfmt (for wslview)
- add shellcheck action
- wslutilities repo back behind a debian test
- force rustup to not modify profiles
<!-- SQUASH_MERGE_END -->


## Testing

- I tested with Debian, since my primary is Ubuntu (so I feel happier deleting Debian).
```powershell
wsl -t Debian
wsl --unregister Debian
wsl --install Debian
```

- Minimal bootstrapping : 

```bash
sudo apt-get update && sudo apt-get -y install vim nfs-common unison jq direnv zip unzip net-tools git rcm
echo "$USER ALL=(ALL:ALL) NOPASSWD:ALL" | sudo tee -a /etc/sudoers.d/lenient
```

- Testing bootstrap.sh
  - We install docker, because this modifies /etc/wsl.conf to include systemd on boot.
```bash
# ... clone this repo on this branch
./bootstrap.sh repos
./bootstrap.sh baseline
...
Created symlink /etc/systemd/system/systemd-binfmt.service → /dev/null.

>>> You might need to restart WSL for binfmt changes to take effect
```

- Do the `wsl --shutdown` restart dance for systemd
- Testing justfile etc.
  - This also tests the systemctl mask
```bash
export PATH=$PATH:~/.local/bin
just prepare
# select login with a web browser and it should transparently open your browser...
# no binfmt nonsense now.
just tools
```





