### PR TITLE
feat: add the ability to checkout and link scripts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,12 @@ name: test
 run-name: Run Tests
 on:
   workflow_dispatch: null
-  pull_request: null
-  push: null
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,10 @@ jobs:
           pip install gh-release-install
           # shellcheck disable=SC2002
           tool_count=$(cat "${{ github.workspace }}/config/tools.yml" | yq -p yaml -o json | jq -c '.[] | (if .repo == null then empty else . end ) | .repo' | wc -l)
+          # shellcheck disable=SC2002
           repo_count=$(cat "${{ github.workspace }}/config/repos.yml" | yq -p yaml -o json | jq -c '.[] | (if .repo == null then empty else . end ) | .repo' | wc -l)
+          # shellcheck disable=SC2003
+          # shellcheck disable=SC2086
           total_count=$(expr $tool_count + $repo_count)
           install_count=$(just tools | grep -c "attempt install")
           if [[ "$total_count" != "$install_count" ]]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,9 +36,11 @@ jobs:
           pip install gh-release-install
           # shellcheck disable=SC2002
           tool_count=$(cat "${{ github.workspace }}/config/tools.yml" | yq -p yaml -o json | jq -c '.[] | (if .repo == null then empty else . end ) | .repo' | wc -l)
+          repo_count=$(cat "${{ github.workspace }}/config/repos.yml" | yq -p yaml -o json | jq -c '.[] | (if .repo == null then empty else . end ) | .repo' | wc -l)
+          total_count=$(expr $tool_count + $repo_count)
           install_count=$(just tools | grep -c "attempt install")
-          if [[ "$tool_count" != "$install_count" ]]; then
-            echo "::error::mismatch between tools.yml [$tool_count] and installed tools [$install_count]"
+          if [[ "$total_count" != "$install_count" ]]; then
+            echo "::error::mismatch between tools.yml [$total_count] and installed tools [$install_count]"
             exit 1
           fi
   test_rust_install:

--- a/Justfile
+++ b/Justfile
@@ -358,8 +358,7 @@ install_repos:
 
   # shellcheck disable=SC2002
   repos=$(cat "{{ REPO_CONFIG }}" | yq_wrapper -p yaml -o json | jq -c ".[]")
-  for line in $repos
-  do
+  for line in $repos; do
     repo=$(echo "$line" | jq -r ".repo")
     contents_line=$(echo "$line" | jq -r ".contents")
     source=$(echo "$contents_line" | cut -f1 -d':')
@@ -369,9 +368,9 @@ install_repos:
     if [[ "$repo" != "null" ]]; then
       if [[ ! -d "{{ LOCAL_SHARE }}/$repo" ]]; then
         echo "[+] $repo (attempt install)"
-        cd "{{ LOCAL_SHARE }}" && git clone --quiet "https://github.com/$repo" "$repo" > /dev/null
+        cd "{{ LOCAL_SHARE }}" && git clone --quiet "https://github.com/$repo" "$repo" >/dev/null
       else
-        pushd "{{ LOCAL_SHARE }}/$repo" > /dev/null
+        pushd "{{ LOCAL_SHARE }}/$repo" >/dev/null
 
         git fetch --quiet
         local=$(git rev-parse @)
@@ -388,11 +387,11 @@ install_repos:
           exit 1
         fi
 
-        popd > /dev/null
+        popd >/dev/null
       fi
 
       if [[ "$destination" != "null" ]]; then
-        if [ ! -L "$HOME/.local/bin/$destination" ] ; then
+        if [ ! -L "$HOME/.local/bin/$destination" ]; then
           ln -s "{{ LOCAL_SHARE }}/$repo/$source" "$HOME/.local/bin/$destination"
         fi
       fi

--- a/Justfile
+++ b/Justfile
@@ -2,6 +2,7 @@ set positional-arguments := true
 OS_NAME:=`uname -o | tr '[:upper:]' '[:lower:]'`
 
 TOOL_CONFIG:=env_var_or_default("DPM_TOOLS_YAML", justfile_directory() / "config/tools.yml")
+REPO_CONFIG:=env_var_or_default("DPM_REPOS_YAML", justfile_directory() / "config/repos.yml")
 
 UPDATECLI_TEMPLATE:=justfile_directory() / "config/updatecli.yml"
 LOCAL_CONFIG:= env_var('HOME') / ".config/ubuntu-dpm"
@@ -47,15 +48,7 @@ updatecli +args='diff':
   rm -rf "$tmpdir"
 
 # Update apt + tools
-update: apt_update tools
-  #!/usr/bin/env bash
-
-  set -eo pipefail
-  # update fzf-git if we need to
-  if [[ -d "{{ LOCAL_SHARE }}/junegunn/fzf-git.sh" ]]; then
-    echo ">>> updating fzf-git"
-    cd "{{ LOCAL_SHARE }}/junegunn/fzf-git.sh" && git pull --rebase
-  fi
+@update: apt_update tools
 
 # initialise to install tools
 init: is_supported configure_ghcli
@@ -65,8 +58,8 @@ init: is_supported configure_ghcli
   mkdir -p ~/.config/direnv && wget -q -O ~/.config/direnv/direnvrc https://raw.githubusercontent.com/direnv/direnv/master/stdlib.sh
   mkdir -p ~/.local/share/direnv/allow
 
-# install binary tools
-@tools: is_supported install_tools
+# install binary tools and checkout repo scripts
+@tools: is_supported install_tools install_repos
 
 # Show help for sdk subcommand
 [private]
@@ -348,6 +341,65 @@ install_tools:
   fi
 
 [private]
+install_repos:
+  #!/usr/bin/env bash
+  set -eo pipefail
+
+  yq_wrapper() {
+    if ! which yq >/dev/null 2>&1; then
+      gh-release-install "mikefarah/yq" "yq_linux_amd64" "$HOME/.local/bin/yq" --version v4.43.1
+      "$HOME/.local/bin/yq" "$@"
+    else
+      yq "$@"
+    fi
+  }
+
+  mkdir -p "{{ LOCAL_SHARE }}"
+
+  # shellcheck disable=SC2002
+  repos=$(cat "{{ REPO_CONFIG }}" | yq_wrapper -p yaml -o json | jq -c ".[]")
+  for line in $repos
+  do
+    repo=$(echo "$line" | jq -r ".repo")
+    contents_line=$(echo "$line" | jq -r ".contents")
+    source=$(echo "$contents_line" | cut -f1 -d':')
+    destination=$(echo "$contents_line" | cut -f2 -d':')
+    source=${source:-$destination}
+
+    if [[ "$repo" != "null" ]]; then
+      if [[ ! -d "{{ LOCAL_SHARE }}/$repo" ]]; then
+        echo "[+] $repo (attempt install)"
+        cd "{{ LOCAL_SHARE }}" && git clone "https://github.com/$repo" "$repo"
+      else
+        pushd "{{ LOCAL_SHARE }}/$repo" > /dev/null
+
+        git fetch --quiet
+        local=$(git rev-parse @)
+        remote=$(git rev-parse '@{u}')
+        base=$(git merge-base @ '@{u}')
+
+        if [ "$local" = "$remote" ]; then
+          echo "[=] $repo (already upto date)"
+        elif [ "$local" = "$base" ]; then
+          echo "[+] $repo (attempt update)"
+          git pull --quiet --rebase
+        else
+          echo "[x] $repo (unexpected state)"
+          exit 1
+        fi
+
+        popd > /dev/null
+      fi
+
+      if [[ "$destination" != "null" ]]; then
+        if [ ! -L "$HOME/.local/bin/$destination" ] ; then
+          ln -s "{{ LOCAL_SHARE }}/$repo/$source" "$HOME/.local/bin/$destination"
+        fi
+      fi
+    fi
+  done
+
+[private]
 configure_ghcli:
   #!/usr/bin/env bash
   set -eo pipefail
@@ -391,23 +443,16 @@ is_supported:
   esac
 
 
-# install & use fzf-git with fzf
+# use fzf-git with fzf
 fzf-git:
   #!/usr/bin/env bash
   set -eo pipefail
 
   SUMMARY=""
-  FZF_GIT="junegunn/fzf-git.sh"
   # install fzf-tmux since it's not in the fzf tar.gz
   if [[ ! -f "{{ LOCAL_BIN }}/fzf-tmux" ]]; then
     curl -fSsL https://raw.githubusercontent.com/junegunn/fzf/master/bin/fzf-tmux -o "{{ LOCAL_BIN }}/fzf-tmux"
     chmod +x "{{ LOCAL_BIN }}/fzf-tmux"
-  fi
-  mkdir -p "{{ LOCAL_SHARE }}"
-  if [[ ! -d "{{ LOCAL_SHARE }}/$FZF_GIT" ]]; then
-    cd "{{ LOCAL_SHARE }}" && git clone "https://github.com/$FZF_GIT" "$FZF_GIT"
-  else
-    cd "{{ LOCAL_SHARE }}/$FZF_GIT" && git pull --rebase
   fi
 
   if [[ -z "$DPM_SKIP_FZF_PROFILE" ]]; then

--- a/Justfile
+++ b/Justfile
@@ -369,7 +369,7 @@ install_repos:
     if [[ "$repo" != "null" ]]; then
       if [[ ! -d "{{ LOCAL_SHARE }}/$repo" ]]; then
         echo "[+] $repo (attempt install)"
-        cd "{{ LOCAL_SHARE }}" && git clone "https://github.com/$repo" "$repo"
+        cd "{{ LOCAL_SHARE }}" && git clone --quiet "https://github.com/$repo" "$repo" > /dev/null
       else
         pushd "{{ LOCAL_SHARE }}/$repo" > /dev/null
 

--- a/config/repos.yml
+++ b/config/repos.yml
@@ -1,0 +1,5 @@
+fzf-git:
+  repo: junegunn/fzf-git.sh
+bitbucket-pr:
+  repo: quotidian-ennui/bitbucket-pr
+  contents: :bb-pr


### PR DESCRIPTION
# Motivation
Installing tools for gh releases is one part of the bootstrapping process, we're now seeing the need to checkout and sometimes link repositories containing shell scripts.


## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- add repos.yml
- add bitbucket-pr to repos, including link
- refactor fzf-git.sh checkout to align with process
- update workflow on to stop duplication
<!-- SQUASH_MERGE_END -->

## Testing

Remove an existing link for `bb-pr` is applicable

```shell
just tools
ls -l ~/.local/share/ubuntu-dpm/
type bb-pr
ls -l  ~/.local/bin/bb-pr
```

