### PR TITLE
fix: add bsdextrautils if debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ just sdk help
 
 Various environment variables control behaviour.
 
-- `SKIP_DOCKER` set to any value if you don't want docker to be installed.
+- `SKIP_DOCKER` | `DPM_SKIP_DOCKER` set to any value if you don't want docker to be installed.
 - `DPM_TOOLS_YAML` can be set to your custom tools build path.
 - `DPM_SKIP_GHCLI_CONFIG` - set to any value if you want to skip github-cli configuration (and authentication etc.).
 - `DPM_SKIP_FZF_PROFILE` - set to any value to skip bashrc shenanigans by `fzf-git`


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->

resolves #136

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- refactor so that distro_name has a single exec
- shfmt -i 2 -w
- apt install bsdextrautils if debian
<!-- SQUASH_MERGE_END -->

