### PR TITLE
refactor: remove just/yq installation logging

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -295,7 +295,6 @@ install_tools:
 
   declare -A installed
   read_installed
-  snap_apt=""
   # shellcheck disable=SC2002
   tools=$(cat "{{ TOOL_CONFIG }}" | yq_wrapper -p yaml -o json | jq -c ".[]")
   for line in $tools
@@ -321,10 +320,6 @@ install_tools:
         # shellcheck disable=SC2086
         gh-release-install "$repo" "$artifact" "{{ LOCAL_BIN }}/$binary" --version "$version" $extract_cmdline
         installed[$binary]="$version"
-        case "$binary" in
-          just | yq) snap_apt="true";;
-          *) ;;
-        esac
       else
         echo "[=] $binary@$version from $repo (already installed)"
         continue
@@ -332,13 +327,6 @@ install_tools:
     fi
   done
   write_installed
-  # Cleanup Just (mpr has it at 1.14)
-  if [[ -n "$snap_apt" ]]; then
-    sudo apt remove -y just 1>/dev/null 2>&1 || true
-    echo ">>> casey/just installed at $(which just)"
-    echo ">>> mikefarah/yq installed at $(which yq)"
-    echo "You might want to 'hash -r' to clear the bash hash cache."
-  fi
 
 [private]
 install_repos:


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->

Since we no longer use snap or just from mpr we don't need to log about it.


## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- remove snap_apt variable use + logging
<!-- SQUASH_MERGE_END -->

## Testing

It should no longer have the `>>> you might want to run hash -r` logging between the last binary tool install, and the repo checkout/update.

```bash
bsh ❯ rm -rf ~/.config/ubuntu-dpm/installed-versions
bsh ❯ rm -rf ~/.local/shared/ubuntu-dpm/junegunn  ~/.local/shared/ubuntu-dpm/quotidian-ennui
bsh ❯ just tools
[+] just@1.25.2 from casey/just (attempt install)
[+] kubectx@v0.9.5 from ahmetb/kubectx (attempt install)
[+] k9s@v0.32.4 from derailed/k9s (attempt install)
[+] terraform-docs@v0.17.0 from terraform-docs/terraform-docs (attempt install)
[+] nova@v3.8.0 from fairwindsops/nova (attempt install)
[+] updatecli@v0.75.0 from updatecli/updatecli (attempt install)
[+] tflint@v0.50.3 from terraform-linters/tflint (attempt install)
[+] gopass@v1.15.13 from gopasspw/gopass (attempt install)
[+] tf-summarize@v0.3.10 from dineshba/tf-summarize (attempt install)
[+] starship@v1.18.2 from starship/starship (attempt install)
[+] shellcheck@v0.10.0 from koalaman/shellcheck (attempt install)
[+] shfmt@v3.8.0 from mvdan/sh (attempt install)
[+] hcledit@v0.2.11 from minamijoyo/hcledit (attempt install)
[+] tfupdate@v0.8.2 from minamijoyo/tfupdate (attempt install)
[+] gron@v0.7.1 from tomnomnom/gron (attempt install)
[+] git-cliff@v2.2.1 from orhun/git-cliff (attempt install)
[+] git-absorb@0.6.13 from tummychow/git-absorb (attempt install)
[+] committed@v1.0.20 from crate-ci/committed (attempt install)
[+] actionlint@v1.6.27 from rhysd/actionlint (attempt install)
[+] yq@v4.43.1 from mikefarah/yq (attempt install)
[+] mutagen@v0.17.5 from mutagen-io/mutagen (attempt install)
[+] lazygit@v0.41.0 from jesseduffield/lazygit (attempt install)
[+] goenv@1.1.8 from ankitcharolia/goenv (attempt install)
[+] difft@0.57.0 from wilfred/difftastic (attempt install)
[+] git-semver@v1.1.1 from psanetra/git-semver (attempt install)
[+] iamlive@v1.1.8 from iann0036/iamlive (attempt install)
[+] qv@v0.8.4 from timvw/qv (attempt install)
[+] gitleaks@v8.18.2 from gitleaks/gitleaks (attempt install)
[+] jf@v0.6.2 from sayanarijit/jf (attempt install)
[+] fzf@0.50.0 from junegunn/fzf (attempt install)
[+] fd@v9.0.0 from sharkdp/fd (attempt install)
[+] bat@v0.24.0 from sharkdp/bat (attempt install)
[+] snyk@v1.1290.0 from snyk/cli (attempt install)
[+] junegunn/fzf-git.sh (attempt install)
[+] quotidian-ennui/bitbucket-pr (attempt install)
```
