### PR TITLE
feat!: add ability to skip profile modification

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -154,7 +154,9 @@ sdk_install_nvm:
   #shellcheck disable=SC1090
   source ~/.nvm/nvm.sh
   nvm install --lts && nvm use --lts
-  npm install -g -y wsl-open pin-github-action prettier
+  if [[ -n "$WSL_DISTRO_NAME" ]]; then
+    npm install -g -y wsl-open
+  fi
 
 
 # Install rustup && cargo-binstall (because rust)

--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ Various environment variables control behaviour.
 - `DPM_TOOLS_YAML` can be set to your custom tools build path.
 - `DPM_SKIP_GHCLI_CONFIG` - set to any value if you want to skip github-cli configuration (and authentication etc.).
 - `DPM_SKIP_FZF_PROFILE` - set to any value to skip bashrc shenanigans by `fzf-git`
+- `DPM_SKIP_JAVA_PROFILE` - set to any value to skip profile modifications by sdkman
+- `DPM_SKIP_NVM_PROFILE` - set to any value to skip profile modifications by nvm
+- `DPM_SKIP_RVM_PROFILE` - set to any value to skip profile modifications by rvm
+- `DPM_SKIP_RUST_PROFILE` - set to any value to skip profile modifications by rustup
 
 ## Notes
 


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->

resolves #135

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- add 'DPM_SKIP_JAVA_PROFILE' to skip sdkman mods
- add 'DPM_SKIP_NVM_PROFILE' to skip nvm mods
- add 'DPM_SKIP_RVM_PROFILE' to skip rvm mods
- add 'DPM_SKIP_RUST_PROFILE' to skip rust mods
- remove pin-github-action && prettier from npm i -g post nvm


BREAKING CHANGE: rustup now defaults back to modifying .bashrc but slightly differently to rustup defaults. We no longer install pin-github-action / prettier globally; use npx to execute them instead.
<!-- SQUASH_MERGE_END -->

## Notes

We always run rustup with --no-modify-paths because it actually scattergun modifies all your profiles. Prefer to have a `[[ -s "$HOME/.cargo/env" ]] &&` style so that we don't break if we share our profiles across systems via rcm or similar.


