### PR TITLE
feat!: remove dependency on ghcli at runtime

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -3,6 +3,7 @@ OS_NAME:=`uname -o | tr '[:upper:]' '[:lower:]'`
 
 TOOL_CONFIG:=env_var_or_default("DPM_TOOLS_YAML", justfile_directory() / "config/tools.yml")
 REPO_CONFIG:=env_var_or_default("DPM_REPOS_YAML", justfile_directory() / "config/repos.yml")
+SDK_CONFIG:=env_var_or_default("DPM_SDK_YAML", justfile_directory() / "config/sdk.yml")
 
 UPDATECLI_TEMPLATE:=justfile_directory() / "config/updatecli.yml"
 LOCAL_CONFIG:= env_var('HOME') / ".config/ubuntu-dpm"
@@ -51,7 +52,7 @@ updatecli +args='diff':
 @update: apt_update tools
 
 # initialise to install tools
-init: is_supported configure_ghcli
+init: is_supported
   #!/usr/bin/env bash
 
   set -eo pipefail
@@ -102,6 +103,8 @@ sdk_install_go:
 [private]
 sdk_install_java:
   #!/usr/bin/env bash
+  #Disable redundant cat throughout the scrsipt.
+  #shellcheck disable=SC2002
   set -eo pipefail
 
   if [[ ! -d "$HOME/.sdkman" ]]; then
@@ -119,24 +122,26 @@ sdk_install_java:
   #shellcheck disable=SC1090
   source ~/.sdkman/bin/sdkman-init.sh
   # graal_latest=$(gh release list -R graalvm/graalvm-ce-builds --json "tagName,isPrerelease,isLatest" -q '.[] | select (.isPrerelease == false) |  select (.isLatest == true) | .tagName')
-  # JDK21 is LTS... so we'll use that
-  graal_latest=jdk-21.0.2
-  gradle_latest=$(gh release list -R gradle/gradle --json "tagName,isPrerelease,isLatest" -q '.[] | select (.isPrerelease == false) |  select (.isLatest == true) | .tagName')
-  maven_latest=$(gh release list -R apache/maven --json "tagName,isPrerelease,isLatest" -q '.[] | select (.isPrerelease == false) |  select (.isLatest == true) | .tagName')
-  jbang_latest=$(gh release list -R jbangdev/jbang --json "tagName,isPrerelease,isLatest" -q '.[] | select (.isPrerelease == false) |  select (.isLatest == true) | .tagName')
+  # gradle_latest=$(gh release list -R gradle/gradle --json "tagName,isPrerelease,isLatest" -q '.[] | select (.isPrerelease == false) |  select (.isLatest == true) | .tagName')
+  # maven_latest=$(gh release list -R apache/maven --json "tagName,isPrerelease,isLatest" -q '.[] | select (.isPrerelease == false) |  select (.isLatest == true) | .tagName')
+  # jbang_latest=$(gh release list -R jbangdev/jbang --json "tagName,isPrerelease,isLatest" -q '.[] | select (.isPrerelease == false) |  select (.isLatest == true) | .tagName')
+  # graal_v=${graal_latest#"jdk-"}
+  # mvn_v=${maven_latest#"maven-"}
+  # gradle_v=${gradle_latest#"v"}
+  # # Need to use 8.5 rather than 8.5.0
+  # gradle_v=${gradle_v%".0"}
+  # jbang_v=${jbang_latest#"v"}
 
-  graal_v=${graal_latest#"jdk-"}
-  mvn_v=${maven_latest#"maven-"}
-  gradle_v=${gradle_latest#"v"}
-  # Need to use 8.5 rather than 8.5.0
-  gradle_v=${gradle_v%".0"}
-  jbang_v=${jbang_latest#"v"}
+  graal_v=$(cat "{{ SDK_CONFIG }}" | yq -r ".sdkman.java")
+  maven_v=$(cat "{{ SDK_CONFIG }}" | yq -r ".sdkman.maven")
+  jbang_v=$(cat "{{ SDK_CONFIG }}" | yq -r ".sdkman.jbang")
+  gradle_v=$(cat "{{ SDK_CONFIG }}" | yq -r ".sdkman.gradle")
 
-  sdk install java "$graal_v-graalce"
+  sdk install java "$graal_v"
   sdk install gradle "$gradle_v"
-  sdk install maven "$mvn_v"
+  sdk install maven "$maven_v"
   sdk install jbang "$jbang_v"
-  echo "[+] GraalVM=$graal_v, Gradle=$gradle_v, Maven=$mvn_v, jbang=$jbang_v"
+  echo "[+] GraalVM=$graal_v, Gradle=$gradle_v, Maven=$maven_v, jbang=$jbang_v"
   sed -e "s|sdkman_auto_answer=true|sdkman_auto_answer=false|g" -i ~/.sdkman/etc/config
 
 # Install NVM (because nodejs)
@@ -145,7 +150,9 @@ sdk_install_nvm:
   #!/usr/bin/env bash
   set -eo pipefail
 
-  nvm_v=$(gh release list -R nvm-sh/nvm --json "tagName,isPrerelease,isLatest" -q '.[] | select (.isPrerelease == false) |  select (.isLatest == true) | .tagName')
+  # nvm_v=$(gh release list -R nvm-sh/nvm --json "tagName,isPrerelease,isLatest" -q '.[] | select (.isPrerelease == false) |  select (.isLatest == true) | .tagName')
+  #shellcheck disable=SC2002
+  nvm_v=$(cat "{{ SDK_CONFIG }}" | yq -r ".nvm.version")
   if [[ -n "$DPM_SKIP_NVM_PROFILE" ]]; then
     curl -fSsL "https://raw.githubusercontent.com/nvm-sh/nvm/$nvm_v/install.sh" | PROFILE=/dev/null bash
   else
@@ -193,7 +200,10 @@ sdk_install_rvm:
   fi
   #shellcheck disable=SC1090
   source ~/.rvm/scripts/rvm
-  ruby_latest=$(gh release list -R ruby/ruby | grep -i Latest | awk '{print $1}')
+  # ruby tagname has _ so we don't derive it like the others.
+  # ruby_latest=$(gh release list -R ruby/ruby | grep -i Latest | awk '{print $1}')
+  #shellcheck disable=SC2002
+  ruby_latest=$(cat "{{ SDK_CONFIG }}" | yq -r ".rvm.ruby")
   ruby_v=${ruby_latest#"v"}
   echo "Ruby $ruby_v" && rvm install ruby "$ruby_v" && rvm use "$ruby_v"
 
@@ -232,7 +242,7 @@ sdk_install_tvm variant:
     #shellcheck disable=SC1083
     ln -s "$HOME/$tfenv_base/bin"/* {{ LOCAL_BIN }}
     #shellcheck disable=SC2002
-    tf_v=$(cat "{{ TOOL_CONFIG }}" | yq -r "$tfenv_yamlpath")
+    tf_v=$(cat "{{ SDK_CONFIG }}" | yq -r "$tfenv_yamlpath")
     "$HOME/$tfenv_base/bin/$tfenv_bin" install "$tf_v"
     "$HOME/$tfenv_base/bin/$tfenv_bin" use "$tf_v"
   fi
@@ -410,22 +420,20 @@ install_repos:
     fi
   done
 
-[private]
-configure_ghcli:
+# configure github cli & extensions
+ghcli:
   #!/usr/bin/env bash
   set -eo pipefail
 
-  if [[ -z "$DPM_SKIP_GHCLI_CONFIG" ]]; then
-    if ! gh auth status >/dev/null 2>&1; then
-      gh auth login -h github.com
-    fi
-    gh extension install quotidian-ennui/gh-my || true
-    gh extension install quotidian-ennui/gh-rate-limit || true
-    gh extension install quotidian-ennui/gh-squash-merge || true
-    gh extension install quotidian-ennui/gh-approve-deploy || true
-    gh extension install actions/gh-actions-cache || true
-    gh extension install mcwarman/gh-update-pr || true
+  if ! gh auth status >/dev/null 2>&1; then
+    gh auth login -h github.com
   fi
+  gh extension install quotidian-ennui/gh-my || true
+  gh extension install quotidian-ennui/gh-rate-limit || true
+  gh extension install quotidian-ennui/gh-squash-merge || true
+  gh extension install quotidian-ennui/gh-approve-deploy || true
+  gh extension install actions/gh-actions-cache || true
+  gh extension install mcwarman/gh-update-pr || true
 
 [private]
 @apt_update:

--- a/Justfile
+++ b/Justfile
@@ -85,7 +85,7 @@ sdk_install_help:
 
 # Install all the SDK tooling
 [private]
-sdk_install_all: sdk_install_go sdk_install_rust sdk_install_nvm sdk_install_java (sdk_install_tvm "terraform") (sdk_install_tvm "opentofu") (sdk_install_aws "update")
+sdk_install_all: sdk_install_go sdk_install_rust sdk_install_nvm sdk_install_java (sdk_install_tvm "opentofu") (sdk_install_aws "update")
 
 # not entirely sure I like this as a chicken & egg situation since goenv must be installed
 # by 'tools' recipe

--- a/Justfile
+++ b/Justfile
@@ -121,16 +121,6 @@ sdk_install_java:
   sed -e "s|sdkman_auto_answer=false|sdkman_auto_answer=true|g" -i ~/.sdkman/etc/config
   #shellcheck disable=SC1090
   source ~/.sdkman/bin/sdkman-init.sh
-  # graal_latest=$(gh release list -R graalvm/graalvm-ce-builds --json "tagName,isPrerelease,isLatest" -q '.[] | select (.isPrerelease == false) |  select (.isLatest == true) | .tagName')
-  # gradle_latest=$(gh release list -R gradle/gradle --json "tagName,isPrerelease,isLatest" -q '.[] | select (.isPrerelease == false) |  select (.isLatest == true) | .tagName')
-  # maven_latest=$(gh release list -R apache/maven --json "tagName,isPrerelease,isLatest" -q '.[] | select (.isPrerelease == false) |  select (.isLatest == true) | .tagName')
-  # jbang_latest=$(gh release list -R jbangdev/jbang --json "tagName,isPrerelease,isLatest" -q '.[] | select (.isPrerelease == false) |  select (.isLatest == true) | .tagName')
-  # graal_v=${graal_latest#"jdk-"}
-  # mvn_v=${maven_latest#"maven-"}
-  # gradle_v=${gradle_latest#"v"}
-  # # Need to use 8.5 rather than 8.5.0
-  # gradle_v=${gradle_v%".0"}
-  # jbang_v=${jbang_latest#"v"}
 
   graal_v=$(cat "{{ SDK_CONFIG }}" | yq -r ".sdkman.java")
   maven_v=$(cat "{{ SDK_CONFIG }}" | yq -r ".sdkman.maven")

--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ Various environment variables control behaviour.
 > The various YAML files should be self explanatory and control
 >
 > - what binary tools are installed (tools.yml)
-> - what sdk tooling is installed (via sdkman|rustup|rvm|nvm etc.).
-> - what github projects are 'cloned' into the local filesystem as supporting tools
+> - what sdk tooling is installed (via sdkman|rustup|rvm|nvm etc.) (sdk.yml)
+> - what github projects are 'cloned' into the local filesystem as supporting tools (repos.yml)
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ echo "$USER ALL=(ALL:ALL) NOPASSWD:ALL" | sudo tee -a /etc/sudoers.d/lenient
 ./bootstrap.sh baseline
 # Now you will need to know your ghcli token info
 just init
+# If you are one to use the github cli
+# just ghcli
 # Install all the tools
 just tools
 # choose your sdk poison
@@ -80,13 +82,20 @@ just sdk help
 Various environment variables control behaviour.
 
 - `SKIP_DOCKER` | `DPM_SKIP_DOCKER` set to any value if you don't want docker to be installed.
-- `DPM_TOOLS_YAML` can be set to your custom tools build path.
-- `DPM_SKIP_GHCLI_CONFIG` - set to any value if you want to skip github-cli configuration (and authentication etc.).
+- `DPM_TOOLS_YAML` - can be set to your custom tools yaml path.
+- `DPM_REPO_YAML` - can be set to your custom repo yaml path
+- `DPM_SDK_YAML` - can be set to your custom sdk yaml path
 - `DPM_SKIP_FZF_PROFILE` - set to any value to skip bashrc shenanigans by `fzf-git`
 - `DPM_SKIP_JAVA_PROFILE` - set to any value to skip profile modifications by sdkman
 - `DPM_SKIP_NVM_PROFILE` - set to any value to skip profile modifications by nvm
 - `DPM_SKIP_RVM_PROFILE` - set to any value to skip profile modifications by rvm
 - `DPM_SKIP_RUST_PROFILE` - set to any value to skip profile modifications by rustup
+
+> The various YAML files should be self explanatory and control
+>
+> - what binary tools are installed (tools.yml)
+> - what sdk tooling is installed (via sdkman|rustup|rvm|nvm etc.).
+> - what github projects are 'cloned' into the local filesystem as supporting tools
 
 ## Notes
 

--- a/config/repos.yml
+++ b/config/repos.yml
@@ -1,3 +1,6 @@
+# Notes:
+# contents == path/to/script:symbolic name in ~/.local/bin
+# so bitbucket/./bb-pr is symlinked to ~/.local/bin/bb-pr
 fzf-git:
   repo: junegunn/fzf-git.sh
 bitbucket-pr:

--- a/config/sdk.yml
+++ b/config/sdk.yml
@@ -1,0 +1,17 @@
+# Should be self evident.
+#
+# terraform probably preserved in aspic now.
+# @see ../updatecli.d/sdk-*.yml
+terraform:
+  version: 1.6.6
+opentofu:
+  version: 1.6.2
+sdkman:
+  java: 21.0.2-graalce
+  gradle: 8.7
+  maven: 3.9.6
+  jbang: 0.116.0
+rvm:
+  ruby: 3.3.1
+nvm:
+  version: v0.39.7

--- a/config/sdk.yml
+++ b/config/sdk.yml
@@ -5,7 +5,7 @@
 terraform:
   version: 1.6.6
 opentofu:
-  version: 1.6.2
+  version: 1.7.0
 sdkman:
   java: 21.0.2-graalce
   gradle: 8.7

--- a/config/tools.yml
+++ b/config/tools.yml
@@ -7,10 +7,6 @@
 # updatecli.pattern == defaults to '*', use a specific version to pin the version
 # updatecli.yamlpath == the yamlpath to update; probably should be defaulted.
 # updatecli.trim_prefix == defaults to ''
-terraform:
-  version: 1.6.6
-opentofu:
-  version: 1.7.0
 just:
   repo: casey/just
   version: 1.25.2

--- a/updatecli.d/sdk-gradle.yml
+++ b/updatecli.d/sdk-gradle.yml
@@ -1,0 +1,58 @@
+# {{ $scmEnabled := and (env "GITHUB_REPOSITORY_OWNER") (env "GITHUB_REPOSITORY_NAME") }}
+name: "gradle"
+
+# {{ if $scmEnabled }}
+actions:
+  pull_request:
+    scmid: github
+    title: 'chore(deps): Bump gradle version to {{ source "latest" }}'
+    kind: github/pullrequest
+    spec:
+      labels:
+        - dependencies
+
+scms:
+  github:
+    disabled: false
+    kind: github
+    spec:
+      branch: main
+      owner: '{{ requiredEnv "GITHUB_REPOSITORY_OWNER" }}'
+      repository: '{{ requiredEnv "GITHUB_REPOSITORY_NAME" }}'
+      user: '{{ requiredEnv "UPDATECLI_GITHUB_USER" }}'
+      email: '{{ requiredEnv "UPDATECLI_GITHUB_EMAIL" }}'
+      username: '{{ requiredEnv "UPDATECLI_GITHUB_USER" }}'
+      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+      commitmessage:
+        type: "chore"
+        scope: "deps"
+        title: 'Bump gradle version to {{ source "latest" }}'
+        hidecredit: true
+# {{ end }}
+
+sources:
+  latest:
+    name: Github release for gradle
+    kind: githubrelease
+    spec:
+      owner: gradle
+      repository: gradle
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      versionfilter:
+        kind: semver
+    transformers:
+      - trimprefix: v
+      - trimsuffix: ".0"
+
+targets:
+  update_yaml:
+    kind: yaml
+    sourceid: latest
+    name: 'Bump gradle version to {{ source "latest" }}'
+    # {{ if $scmEnabled }}
+    scmid: github
+    # {{ end }}
+    spec:
+      files:
+        - ./config/sdk.yml
+      key: $.sdkman.gradle

--- a/updatecli.d/sdk-jbang.yml
+++ b/updatecli.d/sdk-jbang.yml
@@ -1,0 +1,57 @@
+# {{ $scmEnabled := and (env "GITHUB_REPOSITORY_OWNER") (env "GITHUB_REPOSITORY_NAME") }}
+name: "jbang"
+
+# {{ if $scmEnabled }}
+actions:
+  pull_request:
+    scmid: github
+    title: 'chore(deps): Bump jbang version to {{ source "latest" }}'
+    kind: github/pullrequest
+    spec:
+      labels:
+        - dependencies
+
+scms:
+  github:
+    disabled: false
+    kind: github
+    spec:
+      branch: main
+      owner: '{{ requiredEnv "GITHUB_REPOSITORY_OWNER" }}'
+      repository: '{{ requiredEnv "GITHUB_REPOSITORY_NAME" }}'
+      user: '{{ requiredEnv "UPDATECLI_GITHUB_USER" }}'
+      email: '{{ requiredEnv "UPDATECLI_GITHUB_EMAIL" }}'
+      username: '{{ requiredEnv "UPDATECLI_GITHUB_USER" }}'
+      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+      commitmessage:
+        type: "chore"
+        scope: "deps"
+        title: 'Bump jbang version to {{ source "latest" }}'
+        hidecredit: true
+# {{ end }}
+
+sources:
+  latest:
+    name: Github release for jbang
+    kind: githubrelease
+    spec:
+      owner: jbangdev
+      repository: jbang
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      versionfilter:
+        kind: semver
+    transformers:
+      - trimprefix: v
+
+targets:
+  update_yaml:
+    kind: yaml
+    sourceid: latest
+    name: 'Bump jbang version to {{ source "latest" }}'
+    # {{ if $scmEnabled }}
+    scmid: github
+    # {{ end }}
+    spec:
+      files:
+        - ./config/sdk.yml
+      key: $.sdkman.jbang

--- a/updatecli.d/sdk-maven.yml
+++ b/updatecli.d/sdk-maven.yml
@@ -1,0 +1,58 @@
+# {{ $scmEnabled := and (env "GITHUB_REPOSITORY_OWNER") (env "GITHUB_REPOSITORY_NAME") }}
+name: "maven"
+
+# {{ if $scmEnabled }}
+actions:
+  pull_request:
+    scmid: github
+    title: 'chore(deps): Bump maven version to {{ source "latest" }}'
+    kind: github/pullrequest
+    spec:
+      labels:
+        - dependencies
+
+scms:
+  github:
+    disabled: false
+    kind: github
+    spec:
+      branch: main
+      owner: '{{ requiredEnv "GITHUB_REPOSITORY_OWNER" }}'
+      repository: '{{ requiredEnv "GITHUB_REPOSITORY_NAME" }}'
+      user: '{{ requiredEnv "UPDATECLI_GITHUB_USER" }}'
+      email: '{{ requiredEnv "UPDATECLI_GITHUB_EMAIL" }}'
+      username: '{{ requiredEnv "UPDATECLI_GITHUB_USER" }}'
+      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+      commitmessage:
+        type: "chore"
+        scope: "deps"
+        title: 'Bump maven version to {{ source "latest" }}'
+        hidecredit: true
+# {{ end }}
+
+sources:
+  latest:
+    name: Github release for maven
+    kind: githubrelease
+    spec:
+      owner: apache
+      repository: maven
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      versionfilter:
+        kind: regex
+        pattern: ^maven-[0-9]+\.[0-9]+\.[0-9]+$
+    transformers:
+      - trimprefix: maven-
+
+targets:
+  update_yaml:
+    kind: yaml
+    sourceid: latest
+    name: 'Bump maven version to {{ source "latest" }}'
+    # {{ if $scmEnabled }}
+    scmid: github
+    # {{ end }}
+    spec:
+      files:
+        - ./config/sdk.yml
+      key: $.sdkman.maven

--- a/updatecli.d/sdk-nvm.yml
+++ b/updatecli.d/sdk-nvm.yml
@@ -1,0 +1,55 @@
+# {{ $scmEnabled := and (env "GITHUB_REPOSITORY_OWNER") (env "GITHUB_REPOSITORY_NAME") }}
+name: "nvm"
+
+# {{ if $scmEnabled }}
+actions:
+  pull_request:
+    scmid: github
+    title: 'chore(deps): Bump nvm version to {{ source "latest" }}'
+    kind: github/pullrequest
+    spec:
+      labels:
+        - dependencies
+
+scms:
+  github:
+    disabled: false
+    kind: github
+    spec:
+      branch: main
+      owner: '{{ requiredEnv "GITHUB_REPOSITORY_OWNER" }}'
+      repository: '{{ requiredEnv "GITHUB_REPOSITORY_NAME" }}'
+      user: '{{ requiredEnv "UPDATECLI_GITHUB_USER" }}'
+      email: '{{ requiredEnv "UPDATECLI_GITHUB_EMAIL" }}'
+      username: '{{ requiredEnv "UPDATECLI_GITHUB_USER" }}'
+      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+      commitmessage:
+        type: "chore"
+        scope: "deps"
+        title: 'Bump nvm version to {{ source "latest" }}'
+        hidecredit: true
+# {{ end }}
+
+sources:
+  latest:
+    name: Github release for nvm
+    kind: githubrelease
+    spec:
+      owner: nvm-sh
+      repository: nvm
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      versionfilter:
+        kind: semver
+
+targets:
+  update_yaml:
+    kind: yaml
+    sourceid: latest
+    name: 'Bump nvm version to {{ source "latest" }}'
+    # {{ if $scmEnabled }}
+    scmid: github
+    # {{ end }}
+    spec:
+      files:
+        - ./config/sdk.yml
+      key: $.nvm.version

--- a/updatecli.d/sdk-opentofu.yml
+++ b/updatecli.d/sdk-opentofu.yml
@@ -1,0 +1,57 @@
+# {{ $scmEnabled := and (env "GITHUB_REPOSITORY_OWNER") (env "GITHUB_REPOSITORY_NAME") }}
+name: "opentofu"
+
+# {{ if $scmEnabled }}
+actions:
+  pull_request:
+    scmid: github
+    title: 'chore(deps): Bump opentofu version to {{ source "latest" }}'
+    kind: github/pullrequest
+    spec:
+      labels:
+        - dependencies
+
+scms:
+  github:
+    disabled: false
+    kind: github
+    spec:
+      branch: main
+      owner: '{{ requiredEnv "GITHUB_REPOSITORY_OWNER" }}'
+      repository: '{{ requiredEnv "GITHUB_REPOSITORY_NAME" }}'
+      user: '{{ requiredEnv "UPDATECLI_GITHUB_USER" }}'
+      email: '{{ requiredEnv "UPDATECLI_GITHUB_EMAIL" }}'
+      username: '{{ requiredEnv "UPDATECLI_GITHUB_USER" }}'
+      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+      commitmessage:
+        type: "chore"
+        scope: "deps"
+        title: 'Bump opentofu version to {{ source "latest" }}'
+        hidecredit: true
+# {{ end }}
+
+sources:
+  latest:
+    name: Github release for opentofu
+    kind: githubrelease
+    spec:
+      owner: opentofu
+      repository: opentofu
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      versionfilter:
+        kind: semver
+    transformers:
+      - trimprefix: v
+
+targets:
+  update_yaml:
+    kind: yaml
+    sourceid: latest
+    name: 'Bump opentofu version to {{ source "latest" }}'
+    # {{ if $scmEnabled }}
+    scmid: github
+    # {{ end }}
+    spec:
+      files:
+        - ./config/sdk.yml
+      key: $.opentofu.version

--- a/updatecli.d/sdk-ruby.yml
+++ b/updatecli.d/sdk-ruby.yml
@@ -1,13 +1,12 @@
 # {{ $scmEnabled := and (env "GITHUB_REPOSITORY_OWNER") (env "GITHUB_REPOSITORY_NAME") }}
-name: 'opentofu'
+name: "ruby"
 
 # {{ if $scmEnabled }}
 actions:
   pull_request:
     scmid: github
-    title: 'chore(deps): Bump opentofu version to {{ source "latest" }}'
+    title: 'chore(deps): Bump ruby version to {{ source "latest" }}'
     kind: github/pullrequest
-    mergemethod: "squash"
     spec:
       labels:
         - dependencies
@@ -27,32 +26,38 @@ scms:
       commitmessage:
         type: "chore"
         scope: "deps"
-        title: 'Bump opentofu version to {{ source "latest" }}'
+        title: 'Bump ruby version to {{ source "latest" }}'
         hidecredit: true
 # {{ end }}
 
 sources:
   latest:
-    name: Github release for opentofu
+    name: Github release for ruby
     kind: githubrelease
     spec:
-      owner: opentofu
-      repository: opentofu
+      owner: ruby
+      repository: ruby
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      typefilter:
+        latest: true
       versionfilter:
-        kind: semver
+        kind: regex
+        pattern: ^v[0-9]+_[0-9]+_[0-9]+$
     transformers:
       - trimprefix: v
+      - replacer:
+          from: "_"
+          to: "."
 
 targets:
   update_yaml:
     kind: yaml
     sourceid: latest
-    name: 'Bump opentofu version to {{ source "latest" }}'
+    name: 'Bump ruby version to {{ source "latest" }}'
     # {{ if $scmEnabled }}
     scmid: github
     # {{ end }}
     spec:
       files:
-        - ./config/tools.yml
-      key: $.opentofu.version
+        - ./config/sdk.yml
+      key: $.rvm.ruby


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->

resolves #138 

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- switch to an explicit 'sdk.yml' with versions
- remove use of gh release list in justfile
- promote configure_ghcli to a top level recipe as 'ghcli'
- remove DPM_SKIP_GHCLI_CONFIG since it is redundant
- add updatecli configuration for sdk artifacts
- remove terraform install from 'sdk all'

BREAKING CHANGE: tofu|terraform versions moved from tools.yml to sdk.yml. terraform no longer installed by default by 'sdk all'
<!-- SQUASH_MERGE_END -->

## Notes

`$.sdkman.java` doesn't have a corresponding updatecli configuration because at the moment updatecli doesn't have anything similar to `ignore this major version` style functionality, and it will always push us to update to the latest version, even though we want to pin to a java LTS.

> Not exactly happy with updatecli.d/* should be possible to merge that into a single updatecli template a-la config/updatecli.yml...

## Testing

```bash
unset GITHUB_TOKEN
gh auth logout
# since RVM is the least used...
rm -rf ~/.rvm
just sdk rvm
just ghcli
```

should install rvm + ruby 3.3.1 & ask you to login to github again.

