### PR TITLE
feat: add ability to extend config

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -319,8 +319,14 @@ install_tools:
 
   declare -A installed
   read_installed
-  # shellcheck disable=SC2002
-  tools=$(cat "{{ TOOL_CONFIG }}" | yq_wrapper -p yaml -o json | jq -c ".[]")
+
+  files=("{{ TOOL_CONFIG }}")
+  if [[ -n "$DPM_TOOLS_ADDITIONS_YAML" ]]; then
+    files+=("$DPM_TOOLS_ADDITIONS_YAML")
+  fi
+  # shellcheck disable=SC2016
+  tools=$(yq_wrapper -p yaml -o json eval-all '. as $item ireduce ({}; . *+ $item)' "${files[@]}" | jq -c ".[]")
+
   for line in $tools
   do
     repo=$(echo "$line" | jq -r ".repo")
@@ -368,8 +374,13 @@ install_repos:
 
   mkdir -p "{{ LOCAL_SHARE }}"
 
-  # shellcheck disable=SC2002
-  repos=$(cat "{{ REPO_CONFIG }}" | yq_wrapper -p yaml -o json | jq -c ".[]")
+  files=("{{ REPO_CONFIG }}")
+  if [[ -n "$DPM_REPO_ADDITIONS_YAML" ]]; then
+    files+=("$DPM_REPO_ADDITIONS_YAML")
+  fi
+  # shellcheck disable=SC2016
+  repos=$(yq_wrapper -p yaml -o json eval-all '. as $item ireduce ({}; . *+ $item)' "${files[@]}" | jq -c ".[]")
+
   for line in $repos; do
     repo=$(echo "$line" | jq -r ".repo")
     contents_line=$(echo "$line" | jq -r ".contents")

--- a/README.md
+++ b/README.md
@@ -83,7 +83,9 @@ Various environment variables control behaviour.
 
 - `SKIP_DOCKER` | `DPM_SKIP_DOCKER` set to any value if you don't want docker to be installed.
 - `DPM_TOOLS_YAML` - can be set to your custom tools yaml path.
+- `DPM_TOOLS_ADDITIONS_YAML` - can be set to an additional tools yaml path, will be merged base tools.yml
 - `DPM_REPO_YAML` - can be set to your custom repo yaml path
+- `DPM_REPO_ADDITIONS_YAML` - can be set to an additional repos yaml path, will be merged base repos.yml
 - `DPM_SDK_YAML` - can be set to your custom sdk yaml path
 - `DPM_SKIP_FZF_PROFILE` - set to any value to skip bashrc shenanigans by `fzf-git`
 - `DPM_SKIP_JAVA_PROFILE` - set to any value to skip profile modifications by sdkman


### PR DESCRIPTION
# Motivation

Add the ability to add your own tools and repos on top of the existing ones, arguably more useful for repos with dotfiles and other things.

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- add two new properties DPM_TOOLS_ADDITIONS_YAML and DPM_REPO_ADDITIONS_YAML
- creates an array of files that is passed onto yq command
- using yq before processing merge additional yaml with base yaml
<!-- SQUASH_MERGE_END -->

## Testing

```shell
printf 'config/repos-additions.yml' | tee -a .git/info/exclude 
printf 'gitscripts:
  repo: mcwarman/gitscripts
' | tee -a config/repos-additions.yml

printf 'export DPM_REPO_ADDITIONS_YAML="./config/repos-additions.yml"' | tee -a .envrc

just tools
```
