### PR TITLE
fix: switch to using just variable

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -356,8 +356,8 @@ install_tools:
 
   yq_wrapper() {
     if ! which yq >/dev/null 2>&1; then
-      gh-release-install "mikefarah/yq" "yq_linux_amd64" "$HOME/.local/bin/yq" --version v4.43.1
-      "$HOME/.local/bin/yq" "$@"
+      gh-release-install "mikefarah/yq" "yq_linux_amd64" "{{ LOCAL_BIN }}" --version v4.43.1
+      "{{ LOCAL_BIN }}/yq" "$@"
     else
       yq "$@"
     fi
@@ -431,8 +431,8 @@ install_repos:
 
   yq_wrapper() {
     if ! which yq >/dev/null 2>&1; then
-      gh-release-install "mikefarah/yq" "yq_linux_amd64" "$HOME/.local/bin/yq" --version v4.43.1
-      "$HOME/.local/bin/yq" "$@"
+      gh-release-install "mikefarah/yq" "yq_linux_amd64" "{{ LOCAL_BIN }}/yq" --version v4.43.1
+      "{{ LOCAL_BIN }}/yq" "$@"
     else
       yq "$@"
     fi
@@ -480,8 +480,8 @@ install_repos:
       fi
 
       if [[ "$destination" != "null" ]]; then
-        if [ ! -L "$HOME/.local/bin/$destination" ]; then
-          ln -s "{{ LOCAL_SHARE }}/$repo/$source" "$HOME/.local/bin/$destination"
+        if [ ! -L "{{ LOCAL_BIN }}/$destination" ]; then
+          ln -s "{{ LOCAL_SHARE }}/$repo/$source" "{{ LOCAL_BIN }}/$destination"
         fi
       fi
     fi


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->
Resolves #194

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- switch to using just var where appropriate
<!-- SQUASH_MERGE_END -->

## Notes

Not using just variable when writing out the profile changes for fzf to avoid explicitness (in the event that you actually share your dotfiles across multiple machines with different account names).