### PR TITLE
refactor: switch to external scripts not inline

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -21,5 +21,6 @@ jobs:
           reporter: github-pr-review
           pattern: |
             bootstrap.sh
+            src/main/scripts/*.sh
           fail_on_error: true
           github_token: ${{ secrets.github_token }}

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow
 name: updatecli
 on:
   workflow_dispatch: null
@@ -20,6 +21,8 @@ jobs:
     steps:
       - name: "Checkout"
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          fetch-depth: 0
       - name: "Setup updatecli"
         uses: updatecli/updatecli-action@eb158f6fd9e425b940a6750d6318f98e050ac390 # v2.61.0
         with:
@@ -34,27 +37,7 @@ jobs:
           repositories: "${{ github.event.repository.name}}"
       - name: "UpdateCLI"
         run: |
-          set -eo pipefail
-          JQ_FILTER='
-            {
-              "repo": .value.repo,
-              "yamlpath": (if .value.updatecli.yamlpath == null then "$.\(.key).version" else .value.updatecli.yamlpath end),
-              "pattern": (if .value.updatecli.pattern == null then "*" else .value.updatecli.pattern end),
-              "kind": (if .value.updatecli.kind == null then "semver" else .value.updatecli.kind end),
-              "trim_prefix": .value.updatecli.trim_prefix
-            }
-            | with_entries(if .value == null then empty else . end)
-          '
-          # shellcheck disable=SC2002
-          cat "${{ github.workspace }}/config/tools.yml" | yq -p yaml -o json | jq -c "to_entries | .[]" | while read -r line; do
-            values=$(mktemp --tmpdir="${RUNNER_TEMP}" updatecli-values.XXXXXX.yml)
-            hasRepo=$(echo "$line" | jq -r ".value.repo")
-            if [[ "$hasRepo" != "null" ]]; then
-              echo "$line" | jq "$JQ_FILTER" | yq -P -o yaml > "$values"
-              updatecli apply --values "$values" -c "${{ github.workspace }}/config/updatecli.yml"
-            fi
-          done
-          updatecli apply
+          "${{ github.workspace }}/src/main/scripts/updatecli.sh" apply
         env:
           UPDATECLI_GITHUB_USER: ${{ env.UPDATECLI_GITHUB_USER }}
           UPDATECLI_GITHUB_EMAIL: ${{ env.UPDATECLI_GITHUB_EMAIL }}
@@ -63,3 +46,5 @@ jobs:
           GITHUB_REPOSITORY_NAME: ${{ github.event.repository.name }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           UPDATECLI_GH_ACTION: true
+          TOOL_CONFIG: ${{ github.workspace }}/config/tools.yml
+          UPDATECLI_TEMPLATE: ${{ github.workspace }}/config/updatecli.yml

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -47,4 +47,5 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           UPDATECLI_GH_ACTION: true
           TOOL_CONFIG: ${{ github.workspace }}/config/tools.yml
-          UPDATECLI_TEMPLATE: ${{ github.workspace }}/config/updatecli.yml
+          REPO_CONFIG: ${{ github.workspace }}/config/repo.yml
+          SDK_CONFIG: ${{ github.workspace }}/config/sdk.yml

--- a/Justfile
+++ b/Justfile
@@ -1,18 +1,9 @@
 set positional-arguments := true
-OS_NAME:=`uname -o | tr '[:upper:]' '[:lower:]'`
 
 TOOL_CONFIG:=env_var_or_default("DPM_TOOLS_YAML", justfile_directory() / "config/tools.yml")
 REPO_CONFIG:=env_var_or_default("DPM_REPOS_YAML", justfile_directory() / "config/repos.yml")
 SDK_CONFIG:=env_var_or_default("DPM_SDK_YAML", justfile_directory() / "config/sdk.yml")
-
-UPDATECLI_TEMPLATE:=justfile_directory() / "config/updatecli.yml"
 SCRIPTS_DIR:=justfile_directory() / "src/main/scripts"
-
-LOCAL_CONFIG:= env_var('HOME') / ".config/ubuntu-dpm"
-LOCAL_BIN:= env_var('HOME') / ".local/bin"
-LOCAL_SHARE:= env_var('HOME') / ".local/share/ubuntu-dpm"
-GOENV_ROOT:= env_var('HOME') / ".goenv"
-INSTALLED_VERSIONS:= LOCAL_CONFIG / "installed-versions"
 
 alias prepare:=init
 
@@ -25,14 +16,14 @@ alias prepare:=init
 
 # run updatecli with args e.g. just updatecli diff
 @updatecli +args='diff':
-  TOOL_CONFIG="{{ TOOL_CONFIG }}" UPDATECLI_TEMPLATE="{{ UPDATECLI_TEMPLATE }}" "{{ SCRIPTS_DIR }}/updatecli.sh" "$@"
+  TOOL_CONFIG="{{ TOOL_CONFIG }}" REPO_CONFIG="{{ REPO_CONFIG }}" SDK_CONFIG="{{ SDK_CONFIG }}" "{{ SCRIPTS_DIR }}/updatecli.sh" "$@"
 
 # Update apt + tools
 @update: apt_update tools
 
 # initialise to install tools
 @init: is_supported
-  "{{ SCRIPTS_DIR }}/init_direnv.sh"
+  TOOL_CONFIG="{{ TOOL_CONFIG }}" REPO_CONFIG="{{ REPO_CONFIG }}" SDK_CONFIG="{{ SDK_CONFIG }}" "{{ SCRIPTS_DIR }}/init_direnv.sh"
 
 # install binary tools and checkout repo scripts
 @tools: is_supported install_tools install_repos
@@ -57,59 +48,59 @@ sdk_install_all: sdk_install_rust sdk_install_nvm sdk_install_java (sdk_install_
 # Install ankitcharolia/goenv to manage golang
 [private]
 sdk_install_go:
-  SDK_CONFIG="{{ SDK_CONFIG }}" "{{ SCRIPTS_DIR }}/sdk_install_go.sh"
+  TOOL_CONFIG="{{ TOOL_CONFIG }}" REPO_CONFIG="{{ REPO_CONFIG }}" SDK_CONFIG="{{ SDK_CONFIG }}"  "{{ SCRIPTS_DIR }}/sdk_install_go.sh"
 
 # Install/Update go-nv/goenv to manage golang ($1=install/update)
 [private]
 @sdk_install_goenv action="update":
-  LOCAL_BIN="{{ LOCAL_BIN }}" GOENV_ROOT="{{ GOENV_ROOT }}" SDK_CONFIG="{{ SDK_CONFIG }}" "{{ SCRIPTS_DIR }}/sdk_install_goenv.sh" "$@"
+  TOOL_CONFIG="{{ TOOL_CONFIG }}" REPO_CONFIG="{{ REPO_CONFIG }}" SDK_CONFIG="{{ SDK_CONFIG }}" "{{ SCRIPTS_DIR }}/sdk_install_goenv.sh" "$@"
 
 # Install SDKMAN (because JVM)
 [private]
 @sdk_install_java:
-  SDK_CONFIG="{{ SDK_CONFIG }}" "{{ SCRIPTS_DIR }}/sdk_install_java.sh"
+  TOOL_CONFIG="{{ TOOL_CONFIG }}" REPO_CONFIG="{{ REPO_CONFIG }}" SDK_CONFIG="{{ SDK_CONFIG }}" "{{ SCRIPTS_DIR }}/sdk_install_java.sh"
 
 # Install NVM (because nodejs)
 [private]
 @sdk_install_nvm:
-  SDK_CONFIG="{{ SDK_CONFIG }}" "{{ SCRIPTS_DIR }}/sdk_install_nvm.sh"
+  TOOL_CONFIG="{{ TOOL_CONFIG }}" REPO_CONFIG="{{ REPO_CONFIG }}" SDK_CONFIG="{{ SDK_CONFIG }}" "{{ SCRIPTS_DIR }}/sdk_install_nvm.sh"
 
 # Install rustup && cargo-binstall (because rust)
 [private]
 @sdk_install_rust:
-  "{{ SCRIPTS_DIR }}/sdk_install_rust.sh"
+  TOOL_CONFIG="{{ TOOL_CONFIG }}" REPO_CONFIG="{{ REPO_CONFIG }}" SDK_CONFIG="{{ SDK_CONFIG }}" "{{ SCRIPTS_DIR }}/sdk_install_rust.sh"
 
 # Install RVM (because ruby)
 [private]
 sdk_install_rvm:
-  SDK_CONFIG="{{ SDK_CONFIG }}" "{{ SCRIPTS_DIR }}/sdk_install_rvm.sh"
+  TOOL_CONFIG="{{ TOOL_CONFIG }}" REPO_CONFIG="{{ REPO_CONFIG }}" SDK_CONFIG="{{ SDK_CONFIG }}" "{{ SCRIPTS_DIR }}/sdk_install_rvm.sh"
 
 # Install one of the terraform env managers ($1=terraform/opentofu)
 [private]
 @sdk_install_tvm variant:
-  LOCAL_BIN="{{ LOCAL_BIN }}" SDK_CONFIG="{{ SDK_CONFIG }}" "{{ SCRIPTS_DIR }}/sdk_install_tvm.sh" "$@"
+  TOOL_CONFIG="{{ TOOL_CONFIG }}" REPO_CONFIG="{{ REPO_CONFIG }}" SDK_CONFIG="{{ SDK_CONFIG }}" "{{ SCRIPTS_DIR }}/sdk_install_tvm.sh" "$@"
 
 # Install aws-cli ($1=update/install/uninstall)
 [private]
 @sdk_install_aws action="update":
-  "{{ SCRIPTS_DIR }}/sdk_install_aws.sh" "$@"
+  TOOL_CONFIG="{{ TOOL_CONFIG }}" REPO_CONFIG="{{ REPO_CONFIG }}" SDK_CONFIG="{{ SDK_CONFIG }}" "{{ SCRIPTS_DIR }}/sdk_install_aws.sh" "$@"
 
 # Install sonar-scanner cli
 [private]
 @sdk_install_sonar-scanner:
-  LOCAL_BIN="{{ LOCAL_BIN }}" LOCAL_SHARE="{{ LOCAL_SHARE }}" SDK_CONFIG="{{ SDK_CONFIG }}" "{{ SCRIPTS_DIR }}/sdk_install_sonar_scanner.sh" "$@"
+  TOOL_CONFIG="{{ TOOL_CONFIG }}" REPO_CONFIG="{{ REPO_CONFIG }}" SDK_CONFIG="{{ SDK_CONFIG }}" "{{ SCRIPTS_DIR }}/sdk_install_sonar_scanner.sh" "$@"
 
 [private]
 @install_tools:
-  LOCAL_CONFIG="{{ LOCAL_CONFIG }}" INSTALLED_VERSIONS="{{ INSTALLED_VERSIONS }}" LOCAL_BIN="{{ LOCAL_BIN }}" TOOL_CONFIG="{{ TOOL_CONFIG }}" "{{ SCRIPTS_DIR }}/install_tools.sh"
+  TOOL_CONFIG="{{ TOOL_CONFIG }}" REPO_CONFIG="{{ REPO_CONFIG }}" SDK_CONFIG="{{ SDK_CONFIG }}" TOOL_CONFIG="{{ TOOL_CONFIG }}" "{{ SCRIPTS_DIR }}/install_tools.sh"
 
 [private]
 @install_repos:
-  LOCAL_SHARE="{{ LOCAL_SHARE }}" REPO_CONFIG="{{ REPO_CONFIG }}" "{{ SCRIPTS_DIR }}/install_repos.sh"
+  TOOL_CONFIG="{{ TOOL_CONFIG }}" REPO_CONFIG="{{ REPO_CONFIG }}" SDK_CONFIG="{{ SDK_CONFIG }}" "{{ SCRIPTS_DIR }}/install_repos.sh"
 
 # configure github cli & extensions
 @ghcli:
-  "{{ SCRIPTS_DIR }}/configure_ghcli.sh"
+  TOOL_CONFIG="{{ TOOL_CONFIG }}" REPO_CONFIG="{{ REPO_CONFIG }}" SDK_CONFIG="{{ SDK_CONFIG }}"  "{{ SCRIPTS_DIR }}/configure_ghcli.sh"
 
 [private]
 @apt_update:
@@ -120,8 +111,8 @@ sdk_install_rvm:
 [no-cd]
 [no-exit-message]
 @is_supported:
-  "{{ SCRIPTS_DIR }}/is_supported.sh"
+  TOOL_CONFIG="{{ TOOL_CONFIG }}" REPO_CONFIG="{{ REPO_CONFIG }}" SDK_CONFIG="{{ SDK_CONFIG }}" "{{ SCRIPTS_DIR }}/is_supported.sh"
 
 # use fzf-git with fzf
 @fzf-git:
-  LOCAL_BIN="{{ LOCAL_BIN }}" "{{ SCRIPTS_DIR }}/fzf-git.sh"
+  TOOL_CONFIG="{{ TOOL_CONFIG }}" REPO_CONFIG="{{ REPO_CONFIG }}" SDK_CONFIG="{{ SDK_CONFIG }}" "{{ SCRIPTS_DIR }}/fzf-git.sh"

--- a/Justfile
+++ b/Justfile
@@ -6,6 +6,8 @@ REPO_CONFIG:=env_var_or_default("DPM_REPOS_YAML", justfile_directory() / "config
 SDK_CONFIG:=env_var_or_default("DPM_SDK_YAML", justfile_directory() / "config/sdk.yml")
 
 UPDATECLI_TEMPLATE:=justfile_directory() / "config/updatecli.yml"
+SCRIPTS_DIR:=justfile_directory() / "src/main/scripts"
+
 LOCAL_CONFIG:= env_var('HOME') / ".config/ubuntu-dpm"
 LOCAL_BIN:= env_var('HOME') / ".local/bin"
 LOCAL_SHARE:= env_var('HOME') / ".local/share/ubuntu-dpm"
@@ -22,43 +24,15 @@ alias prepare:=init
   echo "Generally, you'll just use 'just tools' to update the binary tools"
 
 # run updatecli with args e.g. just updatecli diff
-updatecli +args='diff':
-  #!/usr/bin/env bash
-  set -eo pipefail
-
-  JQ_FILTER='
-    {
-      "repo": .value.repo,
-      "yamlpath": (if .value.updatecli.yamlpath == null then "$.\(.key).version" else .value.updatecli.yamlpath end),
-      "pattern": (if .value.updatecli.pattern == null then "*" else .value.updatecli.pattern end),
-      "kind": (if .value.updatecli.kind == null then "semver" else .value.updatecli.kind end),
-      "trim_prefix": .value.updatecli.trim_prefix
-    }
-    | with_entries(if .value == null then empty else . end)
-  '
-  tmpdir=$(mktemp -d -t updatecli.XXXXXX)
-  # shellcheck disable=SC2002
-  cat "{{ TOOL_CONFIG }}" | yq -p yaml -o json | jq -c "to_entries | .[]" | while read -r line; do
-    values=$(mktemp --tmpdir="$tmpdir" updatecli-values.XXXXXX.yml)
-    hasRepo=$(echo "$line" | jq -r ".value.repo")
-    if [[ "$hasRepo" != "null" ]]; then
-      echo "$line" | jq "$JQ_FILTER" | yq -P -o yaml > "$values"
-      GITHUB_TOKEN=$(gh auth token) updatecli "$@" --values "$values" -c "{{ UPDATECLI_TEMPLATE }}"
-    fi
-  done
-  GITHUB_TOKEN=$(gh auth token) updatecli "$@"
-  rm -rf "$tmpdir"
+@updatecli +args='diff':
+  TOOL_CONFIG="{{ TOOL_CONFIG }}" UPDATECLI_TEMPLATE="{{ UPDATECLI_TEMPLATE }}" "{{ SCRIPTS_DIR }}/updatecli.sh" "$@"
 
 # Update apt + tools
 @update: apt_update tools
 
 # initialise to install tools
-init: is_supported
-  #!/usr/bin/env bash
-
-  set -eo pipefail
-  mkdir -p ~/.config/direnv && wget -q -O ~/.config/direnv/direnvrc https://raw.githubusercontent.com/direnv/direnv/master/stdlib.sh
-  mkdir -p ~/.local/share/direnv/allow
+@init: is_supported
+  "{{ SCRIPTS_DIR }}/init_direnv.sh"
 
 # install binary tools and checkout repo scripts
 @tools: is_supported install_tools install_repos
@@ -67,18 +41,8 @@ init: is_supported
 [private]
 [no-exit-message]
 [no-cd]
-sdk_install_help:
-  #!/usr/bin/env bash
-
-  set -eo pipefail
-  JUSTFILE_JSON=$(just --dump-format json --dump --unstable)
-  tasks=$(echo "$JUSTFILE_JSON" | jq -c '.recipes | .[] | select( .name | test("^sdk_install_.*")) | { "recipe" : .name, "doc": .doc }')
-  echo "just sdk <action>"
-  while IFS= read -r line; do
-    recipe=$(echo "$line" | jq -r '.recipe')
-    doc=$(echo "$line" | jq -r '.doc')
-    echo "  ${recipe/sdk_install_/}|$doc"
-  done <<< "$tasks" | column -s"|" -t
+@sdk_install_help:
+  "{{ SCRIPTS_DIR }}/just_help.sh" "sdk" "sdk_install_"
 
 # install your preferred set of SDKs
 @sdk action='help' *args="": is_supported
@@ -93,414 +57,59 @@ sdk_install_all: sdk_install_rust sdk_install_nvm sdk_install_java (sdk_install_
 # Install ankitcharolia/goenv to manage golang
 [private]
 sdk_install_go:
-  #!/usr/bin/env bash
-  # shellcheck disable=SC2002
-
-  set -eo pipefail
-  go_v=$(cat "{{ SDK_CONFIG }}" | yq -r ".golang.version")
-  # go_v=$(goenv --list-remote | grep -v -e "beta" -e "rc[0-9]*" | sort -rV | head -n 1)
-  goenv --install "$go_v"
-  goenv --use "$go_v"
-
+  SDK_CONFIG="{{ SDK_CONFIG }}" "{{ SCRIPTS_DIR }}/sdk_install_go.sh"
 
 # Install/Update go-nv/goenv to manage golang ($1=install/update)
 [private]
-sdk_install_goenv action="update":
-  #!/usr/bin/env bash
-  # shellcheck disable=SC2016
-  # shellcheck disable=SC2002
-
-  set -eo pipefail
-  mkdir -p "{{ LOCAL_BIN }}"
-
-  rm -f "{{ LOCAL_BIN }}/goenv"
-  if [[ -d "{{ GOENV_ROOT }}" ]]; then
-    cd "{{ GOENV_ROOT }}" && git pull --rebase
-  else
-    git clone "https://github.com/go-nv/goenv.git" "{{ GOENV_ROOT }}"
-  fi
-  #shellcheck disable=SC1083
-  ln -s "{{ GOENV_ROOT }}/bin/"* {{ LOCAL_BIN }}
-  # shellcheck disable=SC2194
-  case "{{ action }}" in
-  install|latest)
-    if [[ -z "$DPM_SKIP_GO_PROFILE" ]]; then
-      if ! grep -q 'export GOENV_ROOT="$HOME/.goenv"' ~/.bashrc 2>/dev/null; then
-        {
-          printf '\nif [[ -d "$HOME/.goenv" ]]; then'
-          printf '\n  export GOENV_ROOT="$HOME/.goenv"'
-          printf '\n  eval "$($GOENV_ROOT/bin/goenv init -)"'
-          printf '\nfi'
-        } >> ~/.bashrc
-      fi
-    fi
-    go_v=$(cat "{{ SDK_CONFIG }}" | yq -r ".golang.version")
-    "{{ GOENV_ROOT }}/bin/goenv" install -s "$go_v"
-    "{{ GOENV_ROOT }}/bin/goenv" global "$go_v"
-    "{{ GOENV_ROOT }}/bin/goenv" versions
-    ;;
-  *)
-    echo ">>> goenv updated"
-    ;;
-  esac
+@sdk_install_goenv action="update":
+  LOCAL_BIN="{{ LOCAL_BIN }}" GOENV_ROOT="{{ GOENV_ROOT }}" SDK_CONFIG="{{ SDK_CONFIG }}" "{{ SCRIPTS_DIR }}/sdk_install_goenv.sh" "$@"
 
 # Install SDKMAN (because JVM)
 [private]
-sdk_install_java:
-  #!/usr/bin/env bash
-  #Disable redundant cat throughout the scrsipt.
-  #shellcheck disable=SC2002
-  set -eo pipefail
-
-  if [[ ! -d "$HOME/.sdkman" ]]; then
-    # It does feel that if we already have SDKMAN installed then
-    # we could execute sdk selfupdate & sdk upgrade
-    if [[ -n "$DPM_SKIP_JAVA_PROFILE" ]]; then
-      curl -fSsL "https://get.sdkman.io?rcupdate=false" | bash
-    else
-      curl -fSsL "https://get.sdkman.io" | bash
-    fi
-  fi
-  # This is a bit of a hack to avoid the interactive prompt but setting
-  # it on the commandline doesn't always work.
-  sed -e "s|sdkman_auto_answer=false|sdkman_auto_answer=true|g" -i ~/.sdkman/etc/config
-  #shellcheck disable=SC1090
-  source ~/.sdkman/bin/sdkman-init.sh
-
-  graal_v=$(cat "{{ SDK_CONFIG }}" | yq -r ".sdkman.java")
-  maven_v=$(cat "{{ SDK_CONFIG }}" | yq -r ".sdkman.maven")
-  jbang_v=$(cat "{{ SDK_CONFIG }}" | yq -r ".sdkman.jbang")
-  gradle_v=$(cat "{{ SDK_CONFIG }}" | yq -r ".sdkman.gradle")
-
-  sdk install java "$graal_v"
-  sdk install gradle "$gradle_v"
-  sdk install maven "$maven_v"
-  sdk install jbang "$jbang_v"
-  echo "[+] GraalVM=$graal_v, Gradle=$gradle_v, Maven=$maven_v, jbang=$jbang_v"
-  sed -e "s|sdkman_auto_answer=true|sdkman_auto_answer=false|g" -i ~/.sdkman/etc/config
+@sdk_install_java:
+  SDK_CONFIG="{{ SDK_CONFIG }}" "{{ SCRIPTS_DIR }}/sdk_install_java.sh"
 
 # Install NVM (because nodejs)
 [private]
-sdk_install_nvm:
-  #!/usr/bin/env bash
-  set -eo pipefail
-
-  # nvm_v=$(gh release list -R nvm-sh/nvm --json "tagName,isPrerelease,isLatest" -q '.[] | select (.isPrerelease == false) |  select (.isLatest == true) | .tagName')
-  #shellcheck disable=SC2002
-  nvm_v=$(cat "{{ SDK_CONFIG }}" | yq -r ".nvm.version")
-  if [[ -n "$DPM_SKIP_NVM_PROFILE" ]]; then
-    curl -fSsL "https://raw.githubusercontent.com/nvm-sh/nvm/$nvm_v/install.sh" | PROFILE=/dev/null bash
-  else
-    curl -fSsL "https://raw.githubusercontent.com/nvm-sh/nvm/$nvm_v/install.sh" | bash
-  fi
-  #shellcheck disable=SC1090
-  source ~/.nvm/nvm.sh
-  nvm install --lts && nvm use --lts
-  if [[ -n "$WSL_DISTRO_NAME" ]]; then
-    npm install -g -y wsl-open
-  fi
-
+@sdk_install_nvm:
+  SDK_CONFIG="{{ SDK_CONFIG }}" "{{ SCRIPTS_DIR }}/sdk_install_nvm.sh"
 
 # Install rustup && cargo-binstall (because rust)
 [private]
-sdk_install_rust:
-  #!/usr/bin/env bash
-  set -eo pipefail
-
-  # force rustup to not modify profile
-  curl -fSsL --proto '=https' --tlsv1.2 https://sh.rustup.rs | sh -s -- -y --no-modify-path
-  if [[ -z "$DPM_SKIP_RUST_PROFILE" ]]; then
-    if ! grep "\.cargo\/env" "$HOME/.bashrc" >/dev/null 2>&1; then
-      #shellcheck disable=SC2016
-      printf '\n[[ -s "$HOME/.cargo/env" ]] && source "$HOME/.cargo/env"\n' >> "$HOME/.bashrc"
-      echo -e "\n>>> DPM automatically added .cargo/env to .bashrc"
-    fi
-  fi
-
-  curl -fSsL "https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz" | tar xz
-  ./cargo-binstall -y --force cargo-binstall >/dev/null 2>&1
-  rm -f ./cargo-binstall >/dev/null 2>&1
+@sdk_install_rust:
+  "{{ SCRIPTS_DIR }}/sdk_install_rust.sh"
 
 # Install RVM (because ruby)
 [private]
 sdk_install_rvm:
-  #!/usr/bin/env bash
-  set -eo pipefail
-
-  gpg --keyserver keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
-  if [[ -n "$DPM_SKIP_RVM_PROFILE" ]]; then
-    curl -fSsL "https://get.rvm.io" | bash -s stable --ignore-dotfiles
-  else
-    curl -fSsL "https://get.rvm.io" | bash -s stable
-  fi
-  #shellcheck disable=SC1090
-  source ~/.rvm/scripts/rvm
-  # ruby tagname has _ so we don't derive it like the others.
-  # ruby_latest=$(gh release list -R ruby/ruby | grep -i Latest | awk '{print $1}')
-  #shellcheck disable=SC2002
-  ruby_latest=$(cat "{{ SDK_CONFIG }}" | yq -r ".rvm.ruby")
-  ruby_v=${ruby_latest#"v"}
-  echo "Ruby $ruby_v" && rvm install ruby "$ruby_v" && rvm use "$ruby_v"
+  SDK_CONFIG="{{ SDK_CONFIG }}" "{{ SCRIPTS_DIR }}/sdk_install_rvm.sh"
 
 # Install one of the terraform env managers ($1=terraform/opentofu)
 [private]
-sdk_install_tvm variant:
-  #!/usr/bin/env bash
-  set -eo pipefail
-
-  tfenv_base=""
-  tfenv_github=""
-  tfenv_yamlpath=""
-  tfenv_bin=""
-  #shellcheck disable=SC2194
-  case "{{ variant }}" in
-    terraform|tf)
-      tfenv_base=".tfenv"
-      tfenv_github="https://github.com/tfutils/tfenv"
-      tfenv_yamlpath=".terraform.version"
-      tfenv_bin="tfenv"
-      ;;
-    opentofu|tofu)
-      tfenv_base=".tofuenv"
-      tfenv_github="https://github.com/tofuutils/tofuenv"
-      tfenv_yamlpath=".opentofu.version"
-      tfenv_bin="tofuenv"
-      ;;
-    *) echo "Unknown variant: {{ variant }}"; exit 1 ;;
-  esac
-  if [[ -d "$HOME/$tfenv_base" ]]; then
-    echo "{{ variant }} env manager already installed"
-    (cd "$HOME/$tfenv_base" && git pull --rebase)
-  else
-    mkdir -p "{{ LOCAL_BIN }}"
-    (cd "$HOME" && git clone "$tfenv_github" "$tfenv_base")
-    #shellcheck disable=SC1083
-    ln -s "$HOME/$tfenv_base/bin"/* {{ LOCAL_BIN }}
-    #shellcheck disable=SC2002
-    tf_v=$(cat "{{ SDK_CONFIG }}" | yq -r "$tfenv_yamlpath")
-    "$HOME/$tfenv_base/bin/$tfenv_bin" install "$tf_v"
-    "$HOME/$tfenv_base/bin/$tfenv_bin" use "$tf_v"
-  fi
+@sdk_install_tvm variant:
+  LOCAL_BIN="{{ LOCAL_BIN }}" SDK_CONFIG="{{ SDK_CONFIG }}" "{{ SCRIPTS_DIR }}/sdk_install_tvm.sh" "$@"
 
 # Install aws-cli ($1=update/install/uninstall)
 [private]
-sdk_install_aws action="update":
-  #!/usr/bin/env bash
-  set -eo pipefail
-
-  download_and_run_installer() {
-    tmpdir=$(mktemp -d -t awscli.XXXXXX)
-    curl -fSsL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "$tmpdir/awscliv2.zip"
-    unzip -q -d "$tmpdir" "$tmpdir/awscliv2.zip"
-    (cd "$tmpdir" && sudo ./aws/install "$@")
-    rm -rf "$tmpdir"
-  }
-
-  # since action is a just param
-  # shellcheck disable=SC2194
-  case "{{ action }}" in
-    install)
-      download_and_run_installer
-      aws --version
-      ;;
-    uninstall|rm)
-      sudo rm /usr/local/bin/aws
-      sudo rm /usr/local/bin/aws_completer
-      sudo rm -rf /usr/local/aws-cli
-      echo "Skip deleting ~/.aws (chicken mode)"
-      ;;
-    update|upgrade)
-      download_and_run_installer --update
-      aws --version
-      ;;
-    *)
-      echo "Installs / updates the AWS CLI"
-      echo "just aws install|rm|update"
-      exit 0
-      ;;
-  esac
+@sdk_install_aws action="update":
+  "{{ SCRIPTS_DIR }}/sdk_install_aws.sh" "$@"
 
 # Install sonar-scanner cli
 [private]
-sdk_install_sonar-scanner:
-  #!/usr/bin/env bash
-  set -eo pipefail
-
-  mkdir -p "{{ LOCAL_SHARE }}"
-  mkdir -p "{{ LOCAL_BIN }}"
-
-  sonar_v=$(cat "{{ SDK_CONFIG }}" | yq -r ".sonar-scanner.version")
-
-  tmpdir=$(mktemp -d -t sonar.XXXXXX)
-  curl -fSsL "https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${sonar_v}.zip" -o "$tmpdir/sonar-scanner-cli.zip"
-  unzip -q -d "$tmpdir" "$tmpdir/sonar-scanner-cli.zip"
-  rm -rf "{{ LOCAL_SHARE }}/sonar-scanner/"
-  mv "$tmpdir/sonar-scanner-${sonar_v}/" "{{ LOCAL_SHARE }}/sonar-scanner/"
-  rm -rf "$tmpdir"
-  if [ ! -L "{{ LOCAL_BIN }}/sonar-scanner" ]; then
-    ln -s "{{ LOCAL_SHARE }}/sonar-scanner/bin/sonar-scanner" "{{ LOCAL_BIN }}/sonar-scanner"
-  fi
+@sdk_install_sonar-scanner:
+  LOCAL_BIN="{{ LOCAL_BIN }}" LOCAL_SHARE="{{ LOCAL_SHARE }}" SDK_CONFIG="{{ SDK_CONFIG }}" "{{ SCRIPTS_DIR }}/sdk_install_sonar_scanner.sh" "$@"
 
 [private]
-install_tools:
-  #!/usr/bin/env bash
-  # Pre-Reqs:
-  #  sudo apt install jq pipx
-  #  pipx install gh-release-install (https://github.com/jooola/gh-release-install)
-  # We're using SNAP which might require systemd
-  # In /etc/wsl.conf in the linux distro
-  # [boot]
-  # systemd=true
-  # and then do the wsl --shutdown restart dance.
-  set -eo pipefail
-
-  yq_wrapper() {
-    if ! which yq >/dev/null 2>&1; then
-      gh-release-install "mikefarah/yq" "yq_linux_amd64" "{{ LOCAL_BIN }}" --version v4.43.1
-      "{{ LOCAL_BIN }}/yq" "$@"
-    else
-      yq "$@"
-    fi
-  }
-
-  write_installed() {
-    {
-      for i in "${!installed[@]}"; do
-        echo "$i=${installed[$i]}"
-      done
-    } > "{{ INSTALLED_VERSIONS}}"
-  }
-
-  read_installed() {
-    if [[ -f "{{ INSTALLED_VERSIONS}}" ]]; then
-      # shellcheck disable=SC1097
-      while IFS== read -r key value; do
-        installed[$key]=$value
-      done < "{{ INSTALLED_VERSIONS}}"
-    fi
-  }
-
-  mkdir -p "{{ LOCAL_CONFIG }}"
-  mkdir -p "{{ LOCAL_BIN }}"
-
-  declare -A installed
-  read_installed
-
-  files=("{{ TOOL_CONFIG }}")
-  if [[ -n "$DPM_TOOLS_ADDITIONS_YAML" ]]; then
-    files+=("$DPM_TOOLS_ADDITIONS_YAML")
-  fi
-  # shellcheck disable=SC2016
-  tools=$(yq_wrapper -p yaml -o json eval-all '. as $item ireduce ({}; . *+ $item)' "${files[@]}" | jq -c ".[]")
-
-  for line in $tools
-  do
-    repo=$(echo "$line" | jq -r ".repo")
-    version=$(echo "$line" | jq -r ".version")
-    artifact=$(echo "$line" | jq -r ".artifact")
-    contents_line=$(echo "$line" | jq -r ".contents")
-    extract=$(echo "$contents_line" | cut -f1 -d':')
-    binary=$(echo "$contents_line" | cut -f2 -d':')
-    binary=${binary:-$extract}
-    if [[ -n "$extract" ]]; then
-      extract_cmdline="--extract $extract"
-    else
-      extract_cmdline=""
-    fi
-    if [[ "$repo" != "null" ]]
-    then
-      if [[ "${installed[$binary]}" != "$version" || ! -x "{{ LOCAL_BIN }}/$binary" ]]
-      then
-        echo "[+] $binary@$version from $repo (attempt install)"
-        # since extract_cmdline needs to be expanded.
-        # shellcheck disable=SC2086
-        gh-release-install "$repo" "$artifact" "{{ LOCAL_BIN }}/$binary" --version "$version" $extract_cmdline
-        installed[$binary]="$version"
-      else
-        echo "[=] $binary@$version from $repo (already installed)"
-        continue
-      fi
-    fi
-  done
-  write_installed
+@install_tools:
+  LOCAL_CONFIG="{{ LOCAL_CONFIG }}" INSTALLED_VERSIONS="{{ INSTALLED_VERSIONS }}" LOCAL_BIN="{{ LOCAL_BIN }}" TOOL_CONFIG="{{ TOOL_CONFIG }}" "{{ SCRIPTS_DIR }}/install_tools.sh"
 
 [private]
-install_repos:
-  #!/usr/bin/env bash
-  set -eo pipefail
-
-  yq_wrapper() {
-    if ! which yq >/dev/null 2>&1; then
-      gh-release-install "mikefarah/yq" "yq_linux_amd64" "{{ LOCAL_BIN }}/yq" --version v4.43.1
-      "{{ LOCAL_BIN }}/yq" "$@"
-    else
-      yq "$@"
-    fi
-  }
-
-  mkdir -p "{{ LOCAL_SHARE }}"
-
-  files=("{{ REPO_CONFIG }}")
-  if [[ -n "$DPM_REPO_ADDITIONS_YAML" ]]; then
-    files+=("$DPM_REPO_ADDITIONS_YAML")
-  fi
-  # shellcheck disable=SC2016
-  repos=$(yq_wrapper -p yaml -o json eval-all '. as $item ireduce ({}; . *+ $item)' "${files[@]}" | jq -c ".[]")
-
-  for line in $repos; do
-    repo=$(echo "$line" | jq -r ".repo")
-    contents_line=$(echo "$line" | jq -r ".contents")
-    source=$(echo "$contents_line" | cut -f1 -d':')
-    destination=$(echo "$contents_line" | cut -f2 -d':')
-    source=${source:-$destination}
-
-    if [[ "$repo" != "null" ]]; then
-      if [[ ! -d "{{ LOCAL_SHARE }}/$repo" ]]; then
-        echo "[+] $repo (attempt install)"
-        cd "{{ LOCAL_SHARE }}" && git clone --quiet "https://github.com/$repo" "$repo" >/dev/null
-      else
-        pushd "{{ LOCAL_SHARE }}/$repo" >/dev/null
-
-        git fetch --quiet
-        local=$(git rev-parse @)
-        remote=$(git rev-parse '@{u}')
-        base=$(git merge-base @ '@{u}')
-
-        if [ "$local" = "$remote" ]; then
-          echo "[=] $repo (already upto date)"
-        elif [ "$local" = "$base" ]; then
-          echo "[+] $repo (attempt update)"
-          git pull --quiet --rebase
-        else
-          echo "[x] $repo (unexpected state)"
-          exit 1
-        fi
-
-        popd >/dev/null
-      fi
-
-      if [[ "$destination" != "null" ]]; then
-        if [ ! -L "{{ LOCAL_BIN }}/$destination" ]; then
-          ln -s "{{ LOCAL_SHARE }}/$repo/$source" "{{ LOCAL_BIN }}/$destination"
-        fi
-      fi
-    fi
-  done
+@install_repos:
+  LOCAL_SHARE="{{ LOCAL_SHARE }}" REPO_CONFIG="{{ REPO_CONFIG }}" "{{ SCRIPTS_DIR }}/install_repos.sh"
 
 # configure github cli & extensions
-ghcli:
-  #!/usr/bin/env bash
-  set -eo pipefail
-
-  if ! gh auth status >/dev/null 2>&1; then
-    gh auth login -h github.com
-  fi
-  gh extension install quotidian-ennui/gh-my || true
-  gh extension install quotidian-ennui/gh-rate-limit || true
-  gh extension install quotidian-ennui/gh-squash-merge || true
-  gh extension install quotidian-ennui/gh-approve-deploy || true
-  gh extension install actions/gh-actions-cache || true
-  gh extension install mcwarman/gh-update-pr || true
+@ghcli:
+  "{{ SCRIPTS_DIR }}/configure_ghcli.sh"
 
 [private]
 @apt_update:
@@ -510,47 +119,9 @@ ghcli:
 [private]
 [no-cd]
 [no-exit-message]
-is_supported:
-  #!/usr/bin/env bash
-  set -eo pipefail
-
-  # since OS_NAME is a just variable
-  # shellcheck disable=SC2050
-  if [[ "{{ OS_NAME }}" == "msys" ]]; then echo "Try again on WSL2+Ubuntu"; exit 1; fi
-  if [[ -e "/etc/os-release" ]]; then
-    # shellcheck disable=SC1091
-    release=$(. /etc/os-release && echo "$ID" | tr '[:upper:]' '[:lower:]')
-  else
-    release=$(lsb_release -si | tr '[:upper:]' '[:lower:]') || true
-  fi
-  case "$release" in
-    ubuntu|debian) ;;
-    *) echo "Try again on Ubuntu or Debian"; exit 1;;
-  esac
-
+@is_supported:
+  "{{ SCRIPTS_DIR }}/is_supported.sh"
 
 # use fzf-git with fzf
-fzf-git:
-  #!/usr/bin/env bash
-  set -eo pipefail
-
-  SUMMARY=""
-  # install fzf-tmux since it's not in the fzf tar.gz
-  if [[ ! -f "{{ LOCAL_BIN }}/fzf-tmux" ]]; then
-    curl -fSsL https://raw.githubusercontent.com/junegunn/fzf/master/bin/fzf-tmux -o "{{ LOCAL_BIN }}/fzf-tmux"
-    chmod +x "{{ LOCAL_BIN }}/fzf-tmux"
-  fi
-
-  if [[ -z "$DPM_SKIP_FZF_PROFILE" ]]; then
-    if ! grep "fzf --bash" "$HOME/.bashrc" >/dev/null 2>&1; then
-      #shellcheck disable=SC2016
-      printf '\n[[ -s "$HOME/.local/bin/fzf" ]] && eval $($HOME/.local/bin/fzf --bash)\n' >> "$HOME/.bashrc"
-      SUMMARY+="\n>>> Added fzf --bash to .bashrc"
-    fi
-    if ! grep "fzf-git" "$HOME/.bashrc" >/dev/null 2>&1; then
-      #shellcheck disable=SC2016
-      printf '\n[[ -s "$HOME/.local/share/ubuntu-dpm/junegunn/fzf-git.sh/fzf-git.sh" ]] && source "$HOME/.local/share/ubuntu-dpm/junegunn/fzf-git.sh/fzf-git.sh"\n' >> "$HOME/.bashrc"
-      SUMMARY+="\n>>> Added fzf-git.sh to .bashrc"
-    fi
-  fi
-  echo -e "$SUMMARY"
+@fzf-git:
+  LOCAL_BIN="{{ LOCAL_BIN }}" "{{ SCRIPTS_DIR }}/fzf-git.sh"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -71,8 +71,8 @@ repo_trivy() {
 
 # kubectl
 repo_kubectl() {
-  download_keyrings https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key "kubernetes"
-  echo 'deb [signed-by=/usr/share/keyrings/kubernetes.gpg] https://pkgs.k8s.io/core:/stable:/v1.28/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
+  download_keyrings https://pkgs.k8s.io/core:/stable:/v1.30/deb/Release.key "kubernetes"
+  echo 'deb [signed-by=/usr/share/keyrings/kubernetes.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
 }
 
 # helm

--- a/src/main/scripts/common.sh
+++ b/src/main/scripts/common.sh
@@ -1,14 +1,16 @@
 #!/usr/bin/env bash
 
 ROOT=$(git rev-parse --show-toplevel)
+
+SDK_CONFIG=${SDK_CONFIG:-$ROOT/config/sdk.yml}
+TOOL_CONFIG=${TOOL_CONFIG:-$ROOT/config/tools.yml}
+REPO_CONFIG=${REPO_CONFIG:-$ROOT/config/repos.yml}
+
 LOCAL_CONFIG=${LOCAL_CONFIG:-$HOME/.config/ubuntu-dpm}
 LOCAL_SHARE=${LOCAL_SHARE:-$HOME/.local/share/ubuntu-dpm}
 LOCAL_BIN=${LOCAL_BIN:-$HOME/.local/bin}
 INSTALLED_VERSIONS=${INSTALLED_VERSIONS:-$LOCAL_CONFIG/installed-versions}
-SDK_CONFIG=${SDK_CONFIG:-$ROOT/config/sdk.yml}
-TOOL_CONFIG=${TOOL_CONFIG:-$ROOT/config/tools.yml}
 UPDATECLI_TEMPLATE=${UPDATECLI_TEMPLATE:-$ROOT/config/updatecli.yml}
-REPO_CONFIG=${REPO_CONFIG:-$ROOT/config/repos.yml}
 GOENV_ROOT=${GOENV_ROOT:-$HOME/.goenv}
 
 mkdir -p "$LOCAL_SHARE"

--- a/src/main/scripts/common.sh
+++ b/src/main/scripts/common.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+ROOT=$(git rev-parse --show-toplevel)
+LOCAL_CONFIG=${LOCAL_CONFIG:-$HOME/.config/ubuntu-dpm}
+LOCAL_SHARE=${LOCAL_SHARE:-$HOME/.local/share/ubuntu-dpm}
+LOCAL_BIN=${LOCAL_BIN:-$HOME/.local/bin}
+INSTALLED_VERSIONS=${INSTALLED_VERSIONS:-$LOCAL_CONFIG/installed-versions}
+SDK_CONFIG=${SDK_CONFIG:-$ROOT/config/sdk.yml}
+TOOL_CONFIG=${TOOL_CONFIG:-$ROOT/config/tools.yml}
+UPDATECLI_TEMPLATE=${UPDATECLI_TEMPLATE:-$ROOT/config/updatecli.yml}
+REPO_CONFIG=${REPO_CONFIG:-$ROOT/config/repos.yml}
+GOENV_ROOT=${GOENV_ROOT:-$HOME/.goenv}
+
+mkdir -p "$LOCAL_SHARE"
+mkdir -p "$LOCAL_CONFIG"
+mkdir -p "$LOCAL_BIN"
+
+yq_wrapper() {
+  if ! which yq >/dev/null 2>&1; then
+    gh-release-install "mikefarah/yq" "yq_linux_amd64" "$LOCAL_BIN/yq" --version v4.43.1
+    "$LOCAL_BIN/yq" "$@"
+  else
+    yq "$@"
+  fi
+}

--- a/src/main/scripts/configure_ghcli.sh
+++ b/src/main/scripts/configure_ghcli.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-source "$(dirname "$0")/common.sh"
-
 if ! gh auth status >/dev/null 2>&1; then
   gh auth login -h github.com
 fi

--- a/src/main/scripts/configure_ghcli.sh
+++ b/src/main/scripts/configure_ghcli.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+source "$(dirname "$0")/common.sh"
+
+if ! gh auth status >/dev/null 2>&1; then
+  gh auth login -h github.com
+fi
+gh extension install quotidian-ennui/gh-my || true
+gh extension install quotidian-ennui/gh-rate-limit || true
+gh extension install quotidian-ennui/gh-squash-merge || true
+gh extension install quotidian-ennui/gh-approve-deploy || true
+gh extension install actions/gh-actions-cache || true
+gh extension install mcwarman/gh-update-pr || true

--- a/src/main/scripts/fzf-git.sh
+++ b/src/main/scripts/fzf-git.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -eo pipefail
+source "$(dirname "$0")/common.sh"
+
+SUMMARY=""
+# install fzf-tmux since it's not in the fzf tar.gz
+if [[ ! -f "$LOCAL_BIN/fzf-tmux" ]]; then
+  curl -fSsL https://raw.githubusercontent.com/junegunn/fzf/master/bin/fzf-tmux -o "$LOCAL_BIN/fzf-tmux"
+  chmod +x "$LOCAL_BIN/fzf-tmux"
+fi
+
+if [[ -z "$DPM_SKIP_FZF_PROFILE" ]]; then
+  if ! grep "fzf --bash" "$HOME/.bashrc" >/dev/null 2>&1; then
+    #shellcheck disable=SC2016
+    printf '\n[[ -s "$HOME/.local/bin/fzf" ]] && eval $($HOME/.local/bin/fzf --bash)\n' >>"$HOME/.bashrc"
+    SUMMARY+="\n>>> Added fzf --bash to .bashrc"
+  fi
+  if ! grep "fzf-git" "$HOME/.bashrc" >/dev/null 2>&1; then
+    #shellcheck disable=SC2016
+    printf '\n[[ -s "$HOME/.local/share/ubuntu-dpm/junegunn/fzf-git.sh/fzf-git.sh" ]] && source "$HOME/.local/share/ubuntu-dpm/junegunn/fzf-git.sh/fzf-git.sh"\n' >>"$HOME/.bashrc"
+    SUMMARY+="\n>>> Added fzf-git.sh to .bashrc"
+  fi
+fi
+echo -e "$SUMMARY"

--- a/src/main/scripts/init_direnv.sh
+++ b/src/main/scripts/init_direnv.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+mkdir -p ~/.config/direnv && wget -q -O ~/.config/direnv/direnvrc https://raw.githubusercontent.com/direnv/direnv/master/stdlib.sh
+mkdir -p ~/.local/share/direnv/allow

--- a/src/main/scripts/install_repos.sh
+++ b/src/main/scripts/install_repos.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -eo pipefail
+source "$(dirname "$0")/common.sh"
+
+files=("$REPO_CONFIG")
+if [[ -n "$DPM_REPO_ADDITIONS_YAML" ]]; then
+  files+=("$DPM_REPO_ADDITIONS_YAML")
+fi
+# shellcheck disable=SC2016
+repos=$(yq_wrapper -p yaml -o json eval-all '. as $item ireduce ({}; . *+ $item)' "${files[@]}" | jq -c ".[]")
+
+for line in $repos; do
+  repo=$(echo "$line" | jq -r ".repo")
+  contents_line=$(echo "$line" | jq -r ".contents")
+  source=$(echo "$contents_line" | cut -f1 -d':')
+  destination=$(echo "$contents_line" | cut -f2 -d':')
+  source=${source:-$destination}
+
+  if [[ "$repo" != "null" ]]; then
+    if [[ ! -d "$LOCAL_SHARE/$repo" ]]; then
+      echo "[+] $repo (attempt install)"
+      cd "$LOCAL_SHARE" && git clone --quiet "https://github.com/$repo" "$repo" >/dev/null
+    else
+      pushd "$LOCAL_SHARE/$repo" >/dev/null
+
+      git fetch --quiet
+      local=$(git rev-parse @)
+      remote=$(git rev-parse '@{u}')
+      base=$(git merge-base @ '@{u}')
+
+      if [ "$local" = "$remote" ]; then
+        echo "[=] $repo (already upto date)"
+      elif [ "$local" = "$base" ]; then
+        echo "[+] $repo (attempt update)"
+        git pull --quiet --rebase
+      else
+        echo "[x] $repo (unexpected state)"
+        exit 1
+      fi
+
+      popd >/dev/null
+    fi
+
+    if [[ "$destination" != "null" ]]; then
+      if [ ! -L "$LOCAL_BIN/$destination" ]; then
+        ln -s "$LOCAL_SHARE/$repo/$source" "$LOCAL_BIN/$destination"
+      fi
+    fi
+  fi
+done

--- a/src/main/scripts/install_tools.sh
+++ b/src/main/scripts/install_tools.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Pre-Reqs:
+#  sudo apt install jq pipx
+#  pipx install gh-release-install (https://github.com/jooola/gh-release-install)
+# We're using SNAP which might require systemd
+# In /etc/wsl.conf in the linux distro
+# [boot]
+# systemd=true
+# and then do the wsl --shutdown restart dance.
+set -eo pipefail
+source "$(dirname "$0")/common.sh"
+
+write_installed() {
+  {
+    for i in "${!installed[@]}"; do
+      echo "$i=${installed[$i]}"
+    done
+  } >"$INSTALLED_VERSIONS"
+}
+
+read_installed() {
+  if [[ -f "$INSTALLED_VERSIONS" ]]; then
+    # shellcheck disable=SC1097
+    while IFS== read -r key value; do
+      installed[$key]=$value
+    done <"$INSTALLED_VERSIONS"
+  fi
+}
+
+declare -A installed
+read_installed
+
+files=("$TOOL_CONFIG")
+if [[ -n "$DPM_TOOLS_ADDITIONS_YAML" ]]; then
+  files+=("$DPM_TOOLS_ADDITIONS_YAML")
+fi
+# shellcheck disable=SC2016
+tools=$(yq_wrapper -p yaml -o json eval-all '. as $item ireduce ({}; . *+ $item)' "${files[@]}" | jq -c ".[]")
+
+for line in $tools; do
+  repo=$(echo "$line" | jq -r ".repo")
+  version=$(echo "$line" | jq -r ".version")
+  artifact=$(echo "$line" | jq -r ".artifact")
+  contents_line=$(echo "$line" | jq -r ".contents")
+  extract=$(echo "$contents_line" | cut -f1 -d':')
+  binary=$(echo "$contents_line" | cut -f2 -d':')
+  binary=${binary:-$extract}
+  if [[ -n "$extract" ]]; then
+    extract_cmdline="--extract $extract"
+  else
+    extract_cmdline=""
+  fi
+  if [[ "$repo" != "null" ]]; then
+    if [[ "${installed[$binary]}" != "$version" || ! -x "$LOCAL_BIN/$binary" ]]; then
+      echo "[+] $binary@$version from $repo (attempt install)"
+      # since extract_cmdline needs to be expanded.
+      # shellcheck disable=SC2086
+      gh-release-install "$repo" "$artifact" "$LOCAL_BIN/$binary" --version "$version" $extract_cmdline
+      installed[$binary]="$version"
+    else
+      echo "[=] $binary@$version from $repo (already installed)"
+      continue
+    fi
+  fi
+done
+write_installed

--- a/src/main/scripts/is_supported.sh
+++ b/src/main/scripts/is_supported.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+OS_NAME=$(uname -o | tr '[:upper:]' '[:lower:]')
+
+if [[ "$OS_NAME" == "msys" ]]; then
+  echo "Try again on WSL2+Ubuntu"
+  exit 1
+fi
+if [[ -e "/etc/os-release" ]]; then
+  # shellcheck disable=SC1091
+  release=$(. /etc/os-release && echo "$ID" | tr '[:upper:]' '[:lower:]')
+else
+  release=$(lsb_release -si | tr '[:upper:]' '[:lower:]') || true
+fi
+case "$release" in
+ubuntu | debian) ;;
+*)
+  echo "Try again on Ubuntu or Debian"
+  exit 1
+  ;;
+esac

--- a/src/main/scripts/just_help.sh
+++ b/src/main/scripts/just_help.sh
@@ -3,7 +3,6 @@
 # $2 = the prefix (for filtering tasks in the just file
 
 set -eo pipefail
-source "$(dirname "$0")/common.sh"
 
 module=$1
 filter=$2

--- a/src/main/scripts/just_help.sh
+++ b/src/main/scripts/just_help.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# $1 = the module (for logging)
+# $2 = the prefix (for filtering tasks in the just file
+
+set -eo pipefail
+source "$(dirname "$0")/common.sh"
+
+module=$1
+filter=$2
+jq_filter="^$filter.*"
+
+JUSTFILE_JSON=$(just --dump-format json --dump --unstable)
+tasks=$(echo "$JUSTFILE_JSON" | jq --arg jq_filter "$jq_filter" -c '.recipes | .[] | select( .name | test($jq_filter)) | { "recipe" : .name, "doc": .doc }')
+echo "just $module <action>"
+while IFS= read -r line; do
+  recipe=$(echo "$line" | jq -r '.recipe')
+  doc=$(echo "$line" | jq -r '.doc')
+  echo "  ${recipe/$filter/}|$doc"
+done <<<"$tasks" | column -s"|" -t

--- a/src/main/scripts/sdk_install_aws.sh
+++ b/src/main/scripts/sdk_install_aws.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+source "$(dirname "$0")/common.sh"
+
+download_and_run_installer() {
+  tmpdir=$(mktemp -d -t awscli.XXXXXX)
+  curl -fSsL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "$tmpdir/awscliv2.zip"
+  unzip -q -d "$tmpdir" "$tmpdir/awscliv2.zip"
+  (cd "$tmpdir" && sudo ./aws/install "$@")
+  rm -rf "$tmpdir"
+}
+
+case "$1" in
+install)
+  download_and_run_installer
+  aws --version
+  ;;
+uninstall | rm)
+  sudo rm /usr/local/bin/aws
+  sudo rm /usr/local/bin/aws_completer
+  sudo rm -rf /usr/local/aws-cli
+  echo "Skip deleting ~/.aws (chicken mode)"
+  ;;
+update | upgrade)
+  download_and_run_installer --update
+  aws --version
+  ;;
+*)
+  echo "Installs / updates the AWS CLI"
+  echo "just sdk aws install|rm|update"
+  exit 0
+  ;;
+esac

--- a/src/main/scripts/sdk_install_go.sh
+++ b/src/main/scripts/sdk_install_go.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2002
+source "$(dirname "$0")/common.sh"
+
+set -eo pipefail
+go_v=$(cat "$SDK_CONFIG" | yq -r ".golang.version")
+# go_v=$(goenv --list-remote | grep -v -e "beta" -e "rc[0-9]*" | sort -rV | head -n 1)
+goenv --install "$go_v"
+goenv --use "$go_v"

--- a/src/main/scripts/sdk_install_goenv.sh
+++ b/src/main/scripts/sdk_install_goenv.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016
+# shellcheck disable=SC2002
+
+set -eo pipefail
+source "$(dirname "$0")/common.sh"
+
+rm -f "$LOCAL_BIN/goenv"
+if [[ -d "$GOENV_ROOT" ]]; then
+  cd "$GOENV_ROOT" && git pull --rebase
+else
+  git clone "https://github.com/go-nv/goenv.git" "$GOENV_ROOT"
+fi
+#shellcheck disable=SC1083
+ln -s "$GOENV_ROOT/bin/"* "$LOCAL_BIN"
+case "$1" in
+install | latest)
+  if [[ -z "$DPM_SKIP_GO_PROFILE" ]]; then
+    if ! grep -q 'export GOENV_ROOT="$HOME/.goenv"' ~/.bashrc 2>/dev/null; then
+      {
+        printf '\nif [[ -d "$HOME/.goenv" ]]; then'
+        printf '\n  export GOENV_ROOT="$HOME/.goenv"'
+        printf '\n  eval "$($GOENV_ROOT/bin/goenv init -)"'
+        printf '\nfi'
+      } >>~/.bashrc
+    fi
+  fi
+  go_v=$(cat "$SDK_CONFIG" | yq -r ".golang.version")
+  "$GOENV_ROOT/bin/goenv" install -s "$go_v"
+  "$GOENV_ROOT/bin/goenv" global "$go_v"
+  "$GOENV_ROOT/bin/goenv" versions
+  ;;
+*)
+  echo ">>> goenv updated"
+  ;;
+esac

--- a/src/main/scripts/sdk_install_java.sh
+++ b/src/main/scripts/sdk_install_java.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#Disable redundant cat throughout the scrsipt.
+#shellcheck disable=SC2002
+set -eo pipefail
+source "$(dirname "$0")/common.sh"
+
+if [[ ! -d "$HOME/.sdkman" ]]; then
+  # It does feel that if we already have SDKMAN installed then
+  # we could execute sdk selfupdate & sdk upgrade
+  if [[ -n "$DPM_SKIP_JAVA_PROFILE" ]]; then
+    curl -fSsL "https://get.sdkman.io?rcupdate=false" | bash
+  else
+    curl -fSsL "https://get.sdkman.io" | bash
+  fi
+fi
+# This is a bit of a hack to avoid the interactive prompt but setting
+# it on the commandline doesn't always work.
+sed -e "s|sdkman_auto_answer=false|sdkman_auto_answer=true|g" -i ~/.sdkman/etc/config
+#shellcheck disable=SC1090
+source ~/.sdkman/bin/sdkman-init.sh
+
+graal_v=$(cat "$SDK_CONFIG" | yq -r ".sdkman.java")
+maven_v=$(cat "$SDK_CONFIG" | yq -r ".sdkman.maven")
+jbang_v=$(cat "$SDK_CONFIG" | yq -r ".sdkman.jbang")
+gradle_v=$(cat "$SDK_CONFIG" | yq -r ".sdkman.gradle")
+
+sdk install java "$graal_v"
+sdk install gradle "$gradle_v"
+sdk install maven "$maven_v"
+sdk install jbang "$jbang_v"
+echo "[+] GraalVM=$graal_v, Gradle=$gradle_v, Maven=$maven_v, jbang=$jbang_v"
+sed -e "s|sdkman_auto_answer=true|sdkman_auto_answer=false|g" -i ~/.sdkman/etc/config

--- a/src/main/scripts/sdk_install_nvm.sh
+++ b/src/main/scripts/sdk_install_nvm.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+source "$(dirname "$0")/common.sh"
+
+# nvm_v=$(gh release list -R nvm-sh/nvm --json "tagName,isPrerelease,isLatest" -q '.[] | select (.isPrerelease == false) |  select (.isLatest == true) | .tagName')
+#shellcheck disable=SC2002
+nvm_v=$(cat "$SDK_CONFIG" | yq -r ".nvm.version")
+if [[ -n "$DPM_SKIP_NVM_PROFILE" ]]; then
+  curl -fSsL "https://raw.githubusercontent.com/nvm-sh/nvm/$nvm_v/install.sh" | PROFILE=/dev/null bash
+else
+  curl -fSsL "https://raw.githubusercontent.com/nvm-sh/nvm/$nvm_v/install.sh" | bash
+fi
+#shellcheck disable=SC1090
+source ~/.nvm/nvm.sh
+nvm install --lts && nvm use --lts
+if [[ -n "$WSL_DISTRO_NAME" ]]; then
+  npm install -g -y wsl-open
+fi

--- a/src/main/scripts/sdk_install_rust.sh
+++ b/src/main/scripts/sdk_install_rust.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+source "$(dirname "$0")/common.sh"
+
+# force rustup to not modify profile
+curl -fSsL --proto '=https' --tlsv1.2 https://sh.rustup.rs | sh -s -- -y --no-modify-path
+if [[ -z "$DPM_SKIP_RUST_PROFILE" ]]; then
+  if ! grep "\.cargo\/env" "$HOME/.bashrc" >/dev/null 2>&1; then
+    #shellcheck disable=SC2016
+    printf '\n[[ -s "$HOME/.cargo/env" ]] && source "$HOME/.cargo/env"\n' >>"$HOME/.bashrc"
+    echo -e "\n>>> DPM automatically added .cargo/env to .bashrc"
+  fi
+fi
+
+curl -fSsL "https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz" | tar xz
+./cargo-binstall -y --force cargo-binstall >/dev/null 2>&1
+rm -f ./cargo-binstall >/dev/null 2>&1

--- a/src/main/scripts/sdk_install_rvm.sh
+++ b/src/main/scripts/sdk_install_rvm.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+source "$(dirname "$0")/common.sh"
+
+gpg --keyserver keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+if [[ -n "$DPM_SKIP_RVM_PROFILE" ]]; then
+  curl -fSsL "https://get.rvm.io" | bash -s stable --ignore-dotfiles
+else
+  curl -fSsL "https://get.rvm.io" | bash -s stable
+fi
+#shellcheck disable=SC1090
+source ~/.rvm/scripts/rvm
+# ruby tagname has _ so we don't derive it like the others.
+# ruby_latest=$(gh release list -R ruby/ruby | grep -i Latest | awk '{print $1}')
+#shellcheck disable=SC2002
+ruby_latest=$(cat "$SDK_CONFIG" | yq -r ".rvm.ruby")
+ruby_v=${ruby_latest#"v"}
+echo "Ruby $ruby_v" && rvm install ruby "$ruby_v" && rvm use "$ruby_v"

--- a/src/main/scripts/sdk_install_sonar_scanner.sh
+++ b/src/main/scripts/sdk_install_sonar_scanner.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#shellcheck disable=SC2002
+set -eo pipefail
+
+source "$(dirname "$0")/common.sh"
+
+sonar_v=$(cat "$SDK_CONFIG" | yq -r ".sonar-scanner.version")
+
+tmpdir=$(mktemp -d -t sonar.XXXXXX)
+curl -fSsL "https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${sonar_v}.zip" -o "$tmpdir/sonar-scanner-cli.zip"
+unzip -q -d "$tmpdir" "$tmpdir/sonar-scanner-cli.zip"
+rm -rf "$LOCAL_SHARE/sonar-scanner/"
+mv "$tmpdir/sonar-scanner-${sonar_v}/" "$LOCAL_SHARE/sonar-scanner/"
+rm -rf "$tmpdir"
+if [ ! -L "$LOCAL_SHARE/sonar-scanner" ]; then
+  ln -s "$LOCAL_SHARE/sonar-scanner/bin/sonar-scanner" "$LOCAL_SHARE/sonar-scanner"
+fi

--- a/src/main/scripts/sdk_install_sonar_scanner.sh
+++ b/src/main/scripts/sdk_install_sonar_scanner.sh
@@ -12,6 +12,6 @@ unzip -q -d "$tmpdir" "$tmpdir/sonar-scanner-cli.zip"
 rm -rf "$LOCAL_SHARE/sonar-scanner/"
 mv "$tmpdir/sonar-scanner-${sonar_v}/" "$LOCAL_SHARE/sonar-scanner/"
 rm -rf "$tmpdir"
-if [ ! -L "$LOCAL_SHARE/sonar-scanner" ]; then
-  ln -s "$LOCAL_SHARE/sonar-scanner/bin/sonar-scanner" "$LOCAL_SHARE/sonar-scanner"
+if [ ! -L "$LOCAL_BIN/sonar-scanner" ]; then
+  ln -s "$LOCAL_SHARE/sonar-scanner/bin/sonar-scanner" "$LOCAL_BIN/sonar-scanner"
 fi

--- a/src/main/scripts/sdk_install_tvm.sh
+++ b/src/main/scripts/sdk_install_tvm.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+source "$(dirname "$0")/common.sh"
+
+tfenv_base=""
+tfenv_github=""
+tfenv_yamlpath=""
+tfenv_bin=""
+case "$1" in
+terraform | tf)
+  tfenv_base=".tfenv"
+  tfenv_github="https://github.com/tfutils/tfenv"
+  tfenv_yamlpath=".terraform.version"
+  tfenv_bin="tfenv"
+  ;;
+opentofu | tofu)
+  tfenv_base=".tofuenv"
+  tfenv_github="https://github.com/tofuutils/tofuenv"
+  tfenv_yamlpath=".opentofu.version"
+  tfenv_bin="tofuenv"
+  ;;
+*)
+  echo "Unknown variant: $1"
+  exit 1
+  ;;
+esac
+if [[ -d "$HOME/$tfenv_base" ]]; then
+  echo "$1 env manager already installed"
+  (cd "$HOME/$tfenv_base" && git pull --rebase)
+else
+  mkdir -p "$LOCAL_BIN"
+  (cd "$HOME" && git clone "$tfenv_github" "$tfenv_base")
+  #shellcheck disable=SC1083
+  ln -s "$HOME/$tfenv_base/bin"/* "$LOCAL_BIN"
+  #shellcheck disable=SC2002
+  tf_v=$(cat "$SDK_CONFIG" | yq -r "$tfenv_yamlpath")
+  "$HOME/$tfenv_base/bin/$tfenv_bin" install "$tf_v"
+  "$HOME/$tfenv_base/bin/$tfenv_bin" use "$tf_v"
+fi

--- a/src/main/scripts/updatecli.sh
+++ b/src/main/scripts/updatecli.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+source "$(dirname "$0")/common.sh"
+
+JQ_FILTER='
+    {
+      "repo": .value.repo,
+      "yamlpath": (if .value.updatecli.yamlpath == null then "$.\(.key).version" else .value.updatecli.yamlpath end),
+      "pattern": (if .value.updatecli.pattern == null then "*" else .value.updatecli.pattern end),
+      "kind": (if .value.updatecli.kind == null then "semver" else .value.updatecli.kind end),
+      "trim_prefix": .value.updatecli.trim_prefix
+    }
+    | with_entries(if .value == null then empty else . end)
+  '
+
+if [[ -z "$GITHUB_TOKEN" ]]; then
+  GITHUB_TOKEN=$(gh auth token)
+fi
+
+tmpdir=$(mktemp -d -t updatecli.XXXXXX)
+# shellcheck disable=SC2002
+cat "$TOOL_CONFIG" | yq -p yaml -o json | jq -c "to_entries | .[]" | while read -r line; do
+  values=$(mktemp --tmpdir="$tmpdir" updatecli-values.XXXXXX.yml)
+  hasRepo=$(echo "$line" | jq -r ".value.repo")
+  if [[ "$hasRepo" != "null" ]]; then
+    echo "$line" | jq "$JQ_FILTER" | yq -P -o yaml >"$values"
+    GITHUB_TOKEN=$GITHUB_TOKEN updatecli "$@" --values "$values" -c "$UPDATECLI_TEMPLATE"
+  fi
+done
+GITHUB_TOKEN=$GITHUB_TOKEN updatecli "$@"
+rm -rf "$tmpdir"


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->
It is getting to the stage where a monolithic justfile probably isn't great; especially since we have to duplicate functions (yq_wrapper).

Push all the inline scripts as external scripts in src/main/scripts. 

This is the first part of a 2stage PR, the second will be to merge all the sdk_* into a single script...

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- switch to external scripts not inline
- modify updatecli workflow to use script
- add shellcheck on all scripts
<!-- SQUASH_MERGE_END -->

