### PR TITLE
feat: add env-var to specify bash profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Various environment variables control behaviour.
 - `DPM_SKIP_RVM_PROFILE` - set to any value to skip profile modifications by rvm (via _just sdk rvm_)
 - `DPM_SKIP_RUST_PROFILE` - set to any value to skip profile modifications by rustup (via _just sdk rust_)
 - `DPM_SKIP_ARCHIVES_PROFILE` - set to any value to skip profile modifications by archives (via _just install archives_)
+- `DPM_BASH_PROFILE_FILE` - defaults to $HOME/.bashrc but can be set to a different value for '_sdk goenv, sdk rust, install archives, fzf-git_)
 
 > The various YAML files should be self explanatory and control
 >

--- a/src/main/scripts/common.sh
+++ b/src/main/scripts/common.sh
@@ -6,7 +6,7 @@ ROOT=$(git rev-parse --show-toplevel)
 SDK_CONFIG=${SDK_CONFIG:-$ROOT/config/sdk.yml}
 TOOL_CONFIG=${TOOL_CONFIG:-$ROOT/config/tools.yml}
 REPO_CONFIG=${REPO_CONFIG:-$ROOT/config/repos.yml}
-ARCHIVE_CONFIG=${APPDIR_CONFIG:-$ROOT/config/archives.yml}
+ARCHIVE_CONFIG=${ARCHIVE_CONFIG:-$ROOT/config/archives.yml}
 
 LOCAL_CONFIG=${LOCAL_CONFIG:-$HOME/.config/ubuntu-dpm}
 LOCAL_SHARE=${LOCAL_SHARE:-$HOME/.local/share/ubuntu-dpm}
@@ -14,6 +14,7 @@ LOCAL_BIN=${LOCAL_BIN:-$HOME/.local/bin}
 INSTALLED_VERSIONS=${INSTALLED_VERSIONS:-$LOCAL_CONFIG/installed-versions}
 UPDATECLI_TEMPLATE=${UPDATECLI_TEMPLATE:-$ROOT/config/updatecli.yml}
 GOENV_ROOT=${GOENV_ROOT:-$HOME/.goenv}
+DPM_BASH_PROFILE_FILE=${DPM_BASH_PROFILE_FILE:-$HOME/.bashrc}
 
 _init_dirs() {
   mkdir -p "$LOCAL_SHARE"

--- a/src/main/scripts/fzf-git.sh
+++ b/src/main/scripts/fzf-git.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail
+#shellcheck disable=SC1091
 source "$(dirname "$0")/common.sh"
 
 SUMMARY=""
@@ -10,15 +11,15 @@ if [[ ! -f "$LOCAL_BIN/fzf-tmux" ]]; then
 fi
 
 if [[ -z "$DPM_SKIP_FZF_PROFILE" ]]; then
-  if ! grep "fzf --bash" "$HOME/.bashrc" >/dev/null 2>&1; then
+  if ! grep "fzf --bash" "$DPM_BASH_PROFILE_FILE" >/dev/null 2>&1; then
     #shellcheck disable=SC2016
-    printf '\n[[ -s "$HOME/.local/bin/fzf" ]] && eval $($HOME/.local/bin/fzf --bash)\n' >>"$HOME/.bashrc"
-    SUMMARY+="\n>>> Added fzf --bash to .bashrc"
+    printf '\n[[ -s "$HOME/.local/bin/fzf" ]] && eval $($HOME/.local/bin/fzf --bash)\n' >>"$DPM_BASH_PROFILE_FILE"
+    SUMMARY+="\n>>> Added fzf --bash to $DPM_BASH_PROFILE_FILE"
   fi
-  if ! grep "fzf-git" "$HOME/.bashrc" >/dev/null 2>&1; then
+  if ! grep "fzf-git" "$DPM_BASH_PROFILE_FILE" >/dev/null 2>&1; then
     #shellcheck disable=SC2016
     printf '\n[[ -s "$HOME/.local/share/ubuntu-dpm/junegunn/fzf-git.sh/fzf-git.sh" ]] && source "$HOME/.local/share/ubuntu-dpm/junegunn/fzf-git.sh/fzf-git.sh"\n' >>"$HOME/.bashrc"
-    SUMMARY+="\n>>> Added fzf-git.sh to .bashrc"
+    SUMMARY+="\n>>> Added fzf-git.sh to $DPM_BASH_PROFILE_FILE"
   fi
 fi
 echo -e "$SUMMARY"

--- a/src/main/scripts/includes/install_archives
+++ b/src/main/scripts/includes/install_archives
@@ -15,9 +15,9 @@ _archives_check_prereqs() {
 _zips_add_path() {
   path_to_add=$1
   if [[ -z "$DPM_SKIP_ARCHIVES_PROFILE" ]]; then
-    if ! grep "$path_to_add" "$HOME/.bashrc" >/dev/null 2>&1; then
-      printf 'PATH=$PATH:%s\n' "$path_to_add" >>"$HOME/.bashrc"
-      echo "[~] $path_to_add added to ~/.bashrc"
+    if ! grep "$path_to_add" "$DPM_BASH_PROFILE_FILE" >/dev/null 2>&1; then
+      printf 'PATH=$PATH:%s\n' "$path_to_add" >>"$DPM_BASH_PROFILE_FILE"
+      echo "[~] $path_to_add added to $DPM_BASH_PROFILE_FILE"
     fi
   fi
 }

--- a/src/main/scripts/includes/sdk_install_goenv
+++ b/src/main/scripts/includes/sdk_install_goenv
@@ -15,13 +15,14 @@ sdk_install_goenv() {
   case "$1" in
   install | latest)
     if [[ -z "$DPM_SKIP_GO_PROFILE" ]]; then
-      if ! grep -q 'export GOENV_ROOT="$HOME/.goenv"' ~/.bashrc 2>/dev/null; then
+      if ! grep -q 'export GOENV_ROOT="$HOME/.goenv"' "$DPM_BASH_PROFILE_FILE" 2>/dev/null; then
         {
           printf '\nif [[ -d "$HOME/.goenv" ]]; then'
           printf '\n  export GOENV_ROOT="$HOME/.goenv"'
           printf '\n  eval "$($GOENV_ROOT/bin/goenv init -)"'
           printf '\nfi'
-        } >>~/.bashrc
+        } >>"$DPM_BASH_PROFILE_FILE"
+        echo ">>> DPM automatically added goenv to $DPM_BASH_PROFILE_FILE"
       fi
     fi
     go_v=$(cat "$SDK_CONFIG" | yq -r ".golang.version")

--- a/src/main/scripts/includes/sdk_install_rust
+++ b/src/main/scripts/includes/sdk_install_rust
@@ -5,10 +5,10 @@ sdk_install_rust() {
   # force rustup to not modify profile
   curl -fSsL --proto '=https' --tlsv1.2 https://sh.rustup.rs | sh -s -- -y --no-modify-path
   if [[ -z "$DPM_SKIP_RUST_PROFILE" ]]; then
-    if ! grep "\.cargo\/env" "$HOME/.bashrc" >/dev/null 2>&1; then
+    if ! grep "\.cargo\/env" "$DPM_BASH_PROFILE_FILE" >/dev/null 2>&1; then
       #shellcheck disable=SC2016
-      printf '\n[[ -s "$HOME/.cargo/env" ]] && source "$HOME/.cargo/env"\n' >>"$HOME/.bashrc"
-      echo -e "\n>>> DPM automatically added .cargo/env to .bashrc"
+      printf '\n[[ -s "$HOME/.cargo/env" ]] && source "$HOME/.cargo/env"\n' >>"$DPM_BASH_PROFILE_FILE"
+      echo -e "\n>>> DPM automatically added .cargo/env to $DPM_BASH_PROFILE_FILE"
     fi
   fi
 


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->
- Resolves #268
- Defaults to $HOME/.bashrc

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- add DPM_BASH_PROFILE_FILE env-var taht defaults to $HOME/.bashrc
- fixes a typo from #259 
<!-- SQUASH_MERGE_END -->

## Testing

Only modifies things where we directly modify bashrc; NPM/RVM will continue doing what they do.

```console
bsh ❯ just fzf-git

>>> Added fzf --bash to /home/lchan/.bashrc
>>> Added fzf-git.sh to /home/lchan/.bashrc

bsh ❯ just sdk goenv install
Already up to date.
>>> DPM automatically added goenv to /home/lchan/.bashrc
* 1.22.5 (set by /home/lchan/.goenv/version)

bsh ❯ just sdk rust
info: downloading installer
...

>>> DPM automatically added .cargo/env to /home/lchan/.bashrc

bsh ❯ just install archives
[+] joelittlejohn/jsonschema2pojo (attempt install)
[+] quotidian-ennui/parquet-cli-wrapper (attempt install)
[~] /home/lchan/.local/share/ubuntu-dpm/quotidian-ennui/parquet-cli-wrapper added to /home/lchan/.bashrc
```

