### PR TITLE
feat!: remove qv

### DIFF
--- a/config/tools.yml
+++ b/config/tools.yml
@@ -137,15 +137,6 @@ iamlive:
   version: v1.1.10
   artifact: iamlive-{tag}-linux-amd64.tar.gz
   contents: iamlive
-qv:
-  repo: timvw/qv
-  version: v0.8.4
-  artifact: qv-{version}-x86_64-unknown-linux-musl-generic.tar.gz
-  contents: qv
-  updatecli:
-    pattern: v0.8.4
-    # consider pinning because 0.9.6 has no downloadable binaries
-    yamlpath: $.qv.version
 gitleaks:
   repo: gitleaks/gitleaks
   version: v8.18.4


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->

- It's better to 'cargo binstall qv' since it no longer provides binaries
- qv 0.8.4 also isn't reliable

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- remove timvw/qv
<!-- SQUASH_MERGE_END -->

