### PR TITLE
feat: add tstack/lnav

### DIFF
--- a/config/tools.yml
+++ b/config/tools.yml
@@ -177,3 +177,8 @@ dive:
   version: v0.12.0
   artifact: dive_{version}_linux_amd64.tar.gz
   contents: dive
+lnav:
+  repo: tstack/lnav
+  version: v0.12.2
+  artifact: lnav-{version}-linux-musl-x86_64.zip
+  contents: lnav-{version}/lnav:lnav


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->
Because you might want to do `lnav docker://plantuml` (or similar) see https://github.com/tstack/lnav

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- add tstack/lnav
<!-- SQUASH_MERGE_END -->

