### PR TITLE
fix(ci): add condition to golang check

### DIFF
--- a/updatecli.d/sdk-golang.yml
+++ b/updatecli.d/sdk-golang.yml
@@ -44,6 +44,20 @@ sources:
     transformers:
       - trimprefix: go
 
+conditions:
+  check_exists:
+    name: Check exists in goenv github
+    kind: shell
+    disablesourceinput: true
+    spec:
+      shell: bash
+      environments:
+        - name: PATH
+      command: |
+        if curl -fSsL "https://raw.githubusercontent.com/go-nv/goenv/master/plugins/go-build/share/go-build/{{ source "latest"}}" >/dev/null; then
+          echo "Found {{ source "latest" }} in goenv git repo"
+        fi
+
 targets:
   update_yaml:
     kind: yaml


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->
updatecli often detects golang release before goenv has had a chance to update itself (goenv updates nightly with the list of releases). This leads to the situation where the `install-goenv` github action test fails because of timings.

Add a condition to updatecli to curl the corresponding file that goenv will update itself with (pyenv does a similar thing).

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- add an updatecli condition using shell+curl
<!-- SQUASH_MERGE_END -->

