### PR TITLE
feat: add pyenv and goenv to sdk all

### DIFF
--- a/src/main/scripts/includes/sdk_install_all
+++ b/src/main/scripts/includes/sdk_install_all
@@ -4,6 +4,8 @@ sdk_install_all() {
   sdk_install_rust
   sdk_install_nvm
   sdk_install_java
+  sdk_install_pyenv "install"
+  sdk_install_goenv "install"
   sdk_install_tvm "opentofu"
   sdk_install_aws "update"
 }

--- a/src/main/scripts/includes/sdk_install_help
+++ b/src/main/scripts/includes/sdk_install_help
@@ -4,7 +4,7 @@ sdk_install_help() {
   cat <<EOF
 
 Usage: just sdk [$ACTION_LIST] [params]
-  all            Install rust, nvm, sdkman, tofu, aws (but not go).
+  all            Install rust, nvm, sdkman, python, goenv, tofu, aws.
   aws            Install/Update aws-cli
   goenv          Install/Update go-nv/goenv to manage golang
   help           Show help for sdk subcommand


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->
Because of https://github.com/quotidian-ennui/ubuntu-dpm/pull/271 we can now install go via go-nv/goenv for convenience since you don't have to make a choice.

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- add pyenv to sdk all
- add goenv to sdk all
<!-- SQUASH_MERGE_END -->

