### PR TITLE
feat: add updatecli capability for local tools

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -16,8 +16,8 @@ alias prepare:=init
   echo "Generally, you'll just use 'just tools' to update the binary tools"
 
 # run updatecli with args e.g. just updatecli diff
-@updatecli +args='diff':
-  ARCHIVE_CONFIG="{{ ARCHIVE_CONFIG }}" TOOL_CONFIG="{{ TOOL_CONFIG }}" REPO_CONFIG="{{ REPO_CONFIG }}" SDK_CONFIG="{{ SDK_CONFIG }}" "{{ SCRIPTS_DIR }}/updatecli.sh" "$@"
+@updatecli type='personal' +args='diff':
+  UPDATE_TYPE="{{ type }}" ARCHIVE_CONFIG="{{ ARCHIVE_CONFIG }}" TOOL_CONFIG="{{ TOOL_CONFIG }}" REPO_CONFIG="{{ REPO_CONFIG }}" SDK_CONFIG="{{ SDK_CONFIG }}" "{{ SCRIPTS_DIR }}/updatecli.sh" {{ args}}
 
 # Update apt + tools
 @update: apt_update tools

--- a/config/updatecli.yml
+++ b/config/updatecli.yml
@@ -1,5 +1,5 @@
 # {{ $scmEnabled := and (env "GITHUB_REPOSITORY_OWNER") (env "GITHUB_REPOSITORY_NAME") }}
-name: '{{ .repo }}'
+name: "{{ .repo }}"
 
 # {{ if $scmEnabled }}
 actions:
@@ -40,11 +40,11 @@ sources:
       repository: '{{ (split "/" .repo)._1 }}'
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
       versionfilter:
-        kind: '{{ .kind }}'
-        pattern: '{{ .pattern }}'
+        kind: "{{ .kind }}"
+        pattern: "{{ .pattern }}"
     # {{ if .trim_prefix }}
     transformers:
-      - trimprefix: '{{ .trim_prefix }}'
+      - trimprefix: "{{ .trim_prefix }}"
     # {{ end }}
 
 targets:
@@ -57,5 +57,5 @@ targets:
     # {{ end }}
     spec:
       files:
-        - ./config/tools.yml
-      key: '{{ .yamlpath }}'
+        - "{{ .config_file }}"
+      key: "{{ .yamlpath }}"

--- a/src/main/scripts/updatecli.sh
+++ b/src/main/scripts/updatecli.sh
@@ -40,7 +40,6 @@ if [[ -z "$GITHUB_TOKEN" ]]; then
 fi
 
 tmpdir=$(mktemp -d -t updatecli.XXXXXX)
-echo "$@"
 case "$UPDATE_TYPE" in
 additions | local | personal)
   exec_updatecli "$DPM_TOOLS_ADDITIONS_YAML" "$tmpdir" "$@"

--- a/src/main/scripts/updatecli.sh
+++ b/src/main/scripts/updatecli.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
+#shellcheck disable=SC1091
 source "$(dirname "$0")/common.sh"
 
+#shellcheck disable=SC2016
 JQ_FILTER='
     {
+      "config_file": $cfg,
       "repo": .value.repo,
       "yamlpath": (if .value.updatecli.yamlpath == null then "$.\(.key).version" else .value.updatecli.yamlpath end),
       "pattern": (if .value.updatecli.pattern == null then "*" else .value.updatecli.pattern end),
@@ -14,19 +17,38 @@ JQ_FILTER='
     | with_entries(if .value == null then empty else . end)
   '
 
+exec_updatecli() {
+  local config_file="$1"
+  local tmpdir="$2"
+
+  shift 2
+  if [[ -n "$config_file" && -f "$config_file" ]]; then
+    # shellcheck disable=SC2002
+    cat "$config_file" | yq -p yaml -o json | jq -c "to_entries | .[]" | while read -r line; do
+      values=$(mktemp --tmpdir="$tmpdir" updatecli-values.XXXXXX.yml)
+      hasRepo=$(echo "$line" | jq -r ".value.repo")
+      if [[ "$hasRepo" != "null" ]]; then
+        echo "$line" | jq --arg cfg "$config_file" "$JQ_FILTER" | yq -P -o yaml >"$values"
+        GITHUB_TOKEN=$GITHUB_TOKEN updatecli "$@" --values "$values" -c "$UPDATECLI_TEMPLATE"
+      fi
+    done
+  fi
+}
+
 if [[ -z "$GITHUB_TOKEN" ]]; then
   GITHUB_TOKEN=$(gh auth token)
 fi
 
 tmpdir=$(mktemp -d -t updatecli.XXXXXX)
-# shellcheck disable=SC2002
-cat "$TOOL_CONFIG" | yq -p yaml -o json | jq -c "to_entries | .[]" | while read -r line; do
-  values=$(mktemp --tmpdir="$tmpdir" updatecli-values.XXXXXX.yml)
-  hasRepo=$(echo "$line" | jq -r ".value.repo")
-  if [[ "$hasRepo" != "null" ]]; then
-    echo "$line" | jq "$JQ_FILTER" | yq -P -o yaml >"$values"
-    GITHUB_TOKEN=$GITHUB_TOKEN updatecli "$@" --values "$values" -c "$UPDATECLI_TEMPLATE"
-  fi
-done
-GITHUB_TOKEN=$GITHUB_TOKEN updatecli "$@"
+echo "$@"
+case "$UPDATE_TYPE" in
+additions | local | personal)
+  exec_updatecli "$DPM_TOOLS_ADDITIONS_YAML" "$tmpdir" "$@"
+  ;;
+*)
+  exec_updatecli "$TOOL_CONFIG" "$tmpdir" "$@"
+  GITHUB_TOKEN=$GITHUB_TOKEN updatecli "$@"
+  ;;
+esac
+
 rm -rf "$tmpdir"


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->
Running `just updatecli` doesn't support any local tools that you have.

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- add ability to run updatecli against DPM_TOOLS_ADDITIONS_YAML
<!-- SQUASH_MERGE_END -->

## Result

- You should now be able to update any tools that you want to use but aren't in config/tools.yml
- No change to existing github workflow (i.e. running ./src/main/scripts/updatecli.sh apply still just works).

## Testing

- Create an extras.yml that contains something like (12.1.1 is the previous version)
```
tokei:
  repo: XAMPPRocky/tokei
  version: v12.1.1
  artifact: tokei-x86_64-unknown-linux-musl.tar.gz
  contents: tokei
```

- `export DPM_TOOLS_ADDITIONS_YAML=/..../extras.yml`
- `just updatecli local` -> should just check tokei is uptodate
- `just updatecli upstream` -> should check the things in config/tools.yml, _upstream_ can be any string other than `additions|personal|local`
- `just updatecli local apply` -> should bump tokei to a later version (12.1.2)
- `./src/main/scripts/updatecli.sh diff | apply` - which is what the github workflow does should be unaffected.


