### PR TITLE
feat: add update of individual sdkman candidates.

### DIFF
--- a/src/main/scripts/includes/sdk_install_help
+++ b/src/main/scripts/includes/sdk_install_help
@@ -18,15 +18,24 @@ Usage: just sdk [$ACTION_LIST] [params]
 
 Some things have additional paramters as listed here
 'aws'
-  install         : Install the AWS CLI
-  update|upgrade  : Update the AWS CLI
-  uinstall|rm     : Remove the AWS CLI (but not ~/.aws)
+  install             : Install the AWS CLI
+  update|upgrade      : Update the AWS CLI
+  uninstall|rm         : Remove the AWS CLI (but not ~/.aws)
 'goenv' | 'pyenv'
-  install|latest  : Install it
-  update          : Update the git repo that provides it
+  install|latest      : Install it (goenv or pyenv)
+  update              : Update the git repo that provides it
 'tvm'
-  terraform|tf    : install hashicorp/terraform
-  opentofu|tofu   : Install opentofu
+  terraform|tf        : install hashicorp/terraform
+  opentofu|tofu       : Install opentofu
+'java'
+  install             : install baseline java tools (java/gradle/maven/jbang)
+                        For backwards compatibility, this is the default behaviour.
+  upgrade [candidate] : upgrade an sdkman candidate (e.g. gradle) to its latest version
+                        and delete the current version.
+
+                        This behaviour is largely because sdkman leaves previous versions
+                        dangling, and for some tools you never want to use a previous
+                        version.
 EOF
   exit 0
 }

--- a/src/main/scripts/includes/sdk_install_java
+++ b/src/main/scripts/includes/sdk_install_java
@@ -3,7 +3,17 @@
 #shellcheck disable=SC2002
 set -eo pipefail
 
-sdk_install_java() {
+__sdkman_batch_mode() {
+  # This is a bit of a hack to avoid the interactive prompt but setting
+  # it on the commandline doesn't always work.
+  sed -e "s|sdkman_auto_answer=false|sdkman_auto_answer=true|g" -i ~/.sdkman/etc/config
+}
+
+__sdkman_interactive_mode() {
+  sed -e "s|sdkman_auto_answer=true|sdkman_auto_answer=false|g" -i ~/.sdkman/etc/config
+}
+
+__sdkman_base() {
   local graal_v
   local maven_v
   local jbang_v
@@ -18,9 +28,7 @@ sdk_install_java() {
       curl -fSsL "https://get.sdkman.io" | bash
     fi
   fi
-  # This is a bit of a hack to avoid the interactive prompt but setting
-  # it on the commandline doesn't always work.
-  sed -e "s|sdkman_auto_answer=false|sdkman_auto_answer=true|g" -i ~/.sdkman/etc/config
+  __sdkman_batch_mode
   #shellcheck disable=SC1090
   source ~/.sdkman/bin/sdkman-init.sh
 
@@ -34,5 +42,32 @@ sdk_install_java() {
   sdk install maven "$maven_v"
   sdk install jbang "$jbang_v"
   echo "[+] GraalVM=$graal_v, Gradle=$gradle_v, Maven=$maven_v, jbang=$jbang_v"
-  sed -e "s|sdkman_auto_answer=true|sdkman_auto_answer=false|g" -i ~/.sdkman/etc/config
+  __sdkman_interactive_mode
+}
+
+__sdkman_upgrade() {
+  local existing_version
+  local candidate="$1"
+  __sdkman_batch_mode
+  #shellcheck disable=SC1090
+  source ~/.sdkman/bin/sdkman-init.sh
+  sdk selfupdate
+  sdk update
+  existing_version=$(sdk current "$candidate" | grep -Po "([0-9\.]+)")
+  sdk upgrade "$candidate"
+  sdk uninstall "$candidate" "$existing_version"
+  __sdkman_interactive_mode
+}
+
+sdk_install_java() {
+  case "$1" in
+  upgrade)
+    shift
+    __sdkman_upgrade "$@"
+    sdk current
+    ;;
+  *)
+    __sdkman_base
+    ;;
+  esac
 }


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->
You already have sdkman installed, and you don't want to install it again, and all the packages. You just want to upgrade a single sdkman candidate and remove the previous version. This is often true if you're upgrading a build tool like gradle/maven etc. 

You could run `sdkman upgrade` directly, but you are lazy and you don't want to have to run `sdk uninstall xxx 1.2.3` afterwards.

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- add upgrade capability with post upgrade deletion of previous.
<!-- SQUASH_MERGE_END -->

## Testing

Let's say you have liquibase 4.29.0 installed, now you can do this:

```shell
bsh ❯ just sdk java upgrade liquibase
No update available at this time.

No new candidates found at this time.

Available defaults:
liquibase (local: 4.29.0; default: 4.29.2)

Downloading: liquibase 4.29.2

In progress...

Installing: liquibase 4.29.2
Done installing!


Setting liquibase 4.29.2 as default.
removed liquibase 4.29.0.

Using:

gradle: 8.9
java: 21.0.2-graalce
jbang: 0.119.0
liquibase: 4.29.2
maven: 3.9.9
quarkus: 3.15.1
```
