### PR TITLE
feat: add joerdav/xc

### DIFF
--- a/config/tools.yml
+++ b/config/tools.yml
@@ -182,3 +182,8 @@ lnav:
   version: v0.12.2
   artifact: lnav-{version}-linux-musl-x86_64.zip
   contents: lnav-{version}/lnav:lnav
+xc:
+  repo: joerdav/xc
+  version: v0.8.0
+  artifact: xc_{version}_linux_amd64
+  contents: :xc


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->
I thought it was always included in my baseline toolset; imagine my surprise when it wasn't.

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- add joerdav/xc
<!-- SQUASH_MERGE_END -->

