### PR TITLE
feat(sdk-aws): add ecr docker credential helper

### DIFF
--- a/config/sdk.yml
+++ b/config/sdk.yml
@@ -21,3 +21,5 @@ sonar-scanner:
   version: 5.0.1.3006
 python:
   version: 3.12.7
+amazon-ecr-credential-helper:
+  version: 0.9.0

--- a/src/main/scripts/includes/sdk_install_aws
+++ b/src/main/scripts/includes/sdk_install_aws
@@ -36,9 +36,10 @@ aws_download_and_run_installer() {
 }
 
 aws_download_docker_credential_ecr_login() {
-  mkdir -p ~/.local/bin
-  curl -fSsL https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.9.0/linux-amd64/docker-credential-ecr-login -o "${HOME}/.local/bin/docker-credential-ecr-login"
-  chmod +x "${HOME}/.local/bin/docker-credential-ecr-login"
+  mkdir -p "$LOCAL_BIN"
+  version=$(yq -r ".amazon-ecr-credential-helper.version" "$SDK_CONFIG")
+  curl -fSsL "https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/${version}/linux-amd64/docker-credential-ecr-login" -o "$LOCAL_BIN/docker-credential-ecr-login"
+  chmod +x "$LOCAL_BIN/docker-credential-ecr-login"
   echo "Consider adding the following to ~/.docker/config.json"
   printf '{\n  "credHelpers": {\n    "public.ecr.aws": "ecr-login",\n    "<aws_account_id>.dkr.ecr.<region>.amazonaws.com": "ecr-login"\n  }\n}\n'
 }

--- a/src/main/scripts/includes/sdk_install_aws
+++ b/src/main/scripts/includes/sdk_install_aws
@@ -5,6 +5,7 @@ sdk_install_aws() {
   case "$1" in
   install)
     aws_download_and_run_installer
+    aws_download_docker_credential_ecr_login
     aws --version
     ;;
   uninstall | rm)
@@ -15,6 +16,7 @@ sdk_install_aws() {
     ;;
   update | upgrade)
     aws_download_and_run_installer --update
+    aws_download_docker_credential_ecr_login
     aws --version
     ;;
   *)
@@ -31,4 +33,12 @@ aws_download_and_run_installer() {
   unzip -q -d "$tmpdir" "$tmpdir/awscliv2.zip"
   (cd "$tmpdir" && sudo ./aws/install "$@")
   rm -rf "$tmpdir"
+}
+
+aws_download_docker_credential_ecr_login() {
+  mkdir -p ~/.local/bin
+  curl -fSsL https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.9.0/linux-amd64/docker-credential-ecr-login -o "${HOME}/.local/bin/docker-credential-ecr-login"
+  chmod +x "${HOME}/.local/bin/docker-credential-ecr-login"
+  echo "Consider adding the following to ~/.docker/config.json"
+  printf '{\n  "credHelpers": {\n    "public.ecr.aws": "ecr-login",\n    "<aws_account_id>.dkr.ecr.<region>.amazonaws.com": "ecr-login"\n  }\n}\n'
 }

--- a/updatecli.d/sdk-amazon-ecr-credential-helper.yml
+++ b/updatecli.d/sdk-amazon-ecr-credential-helper.yml
@@ -1,0 +1,57 @@
+# {{ $scmEnabled := and (env "GITHUB_REPOSITORY_OWNER") (env "GITHUB_REPOSITORY_NAME") }}
+name: "amazon-ecr-credential-helper"
+
+# {{ if $scmEnabled }}
+actions:
+  pull_request:
+    scmid: github
+    title: 'chore(deps): Bump amazon-ecr-credential-helper version to {{ source "latest" }}'
+    kind: github/pullrequest
+    spec:
+      labels:
+        - dependencies
+
+scms:
+  github:
+    disabled: false
+    kind: github
+    spec:
+      branch: main
+      owner: '{{ requiredEnv "GITHUB_REPOSITORY_OWNER" }}'
+      repository: '{{ requiredEnv "GITHUB_REPOSITORY_NAME" }}'
+      user: '{{ requiredEnv "UPDATECLI_GITHUB_USER" }}'
+      email: '{{ requiredEnv "UPDATECLI_GITHUB_EMAIL" }}'
+      username: '{{ requiredEnv "UPDATECLI_GITHUB_USER" }}'
+      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+      commitmessage:
+        type: "chore"
+        scope: "deps"
+        title: 'Bump amazon-ecr-credential-helper version to {{ source "latest" }}'
+        hidecredit: true
+# {{ end }}
+
+sources:
+  latest:
+    name: Github release for amazon-ecr-credential-helper
+    kind: githubrelease
+    spec:
+      owner: awslabs
+      repository: amazon-ecr-credential-helper
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      versionfilter:
+        kind: semver
+    transformers:
+      - trimprefix: v
+
+targets:
+  update_yaml:
+    kind: yaml
+    sourceid: latest
+    name: 'Bump amazon-ecr-credential-helper version to {{ source "latest" }}'
+    # {{ if $scmEnabled }}
+    scmid: github
+    # {{ end }}
+    spec:
+      files:
+        - ./config/sdk.yml
+      key: $.amazon-ecr-credential-helper.version


### PR DESCRIPTION
# Motivation
Add [amazon-ecr-credential-helper](https://github.com/awslabs/amazon-ecr-credential-helper) as a part of `just sdk aws`

This means you don't have to do 

```shell
aws ecr get-login-password | docker login --username AWS "<registry>"
```

Once set up `docker pull ...` works.

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- add download function for amazon-ecr-credential-helper
- add updatecli config to keep version up to date
<!-- SQUASH_MERGE_END -->

