### PR TITLE
refactor(archives): slightly better path mangling

### DIFF
--- a/src/main/scripts/includes/install_archives
+++ b/src/main/scripts/includes/install_archives
@@ -16,7 +16,9 @@ _zips_add_path() {
   path_to_add=$1
   if [[ -z "$DPM_SKIP_ARCHIVES_PROFILE" ]]; then
     if ! grep "$path_to_add" "$DPM_BASH_PROFILE_FILE" >/dev/null 2>&1; then
-      printf '\nPATH=$PATH:%s\n' "$path_to_add" >>"$DPM_BASH_PROFILE_FILE"
+      {
+        printf '\n[[ -d "%s" ]] && PATH=$PATH:%s\n' "$path_to_add" "$path_to_add"
+      } >>"$DPM_BASH_PROFILE_FILE"
       echo "[~] $path_to_add added to $DPM_BASH_PROFILE_FILE"
     fi
   fi


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->
- `rcup` means I (might) end up sharing my .bashrc file across machines
- I installed wvlet on my laptop, but not on my desktop
- I felt sad when wvlet appeared when I did "echo $PATH" on my desktop


## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- add directory detection before path addition
<!-- SQUASH_MERGE_END -->

## Testing

```
export DPM_ARCHIVES_ADDITIONS_YAML=..../extra_archives.yml
echo '
wvlet:
  repo: wvlet/wvlet
  version:
    github_tag: v2024.9.7
    strip_prefix: v
  artifact: "wvlet-cli-{version}.tar.gz"
  extract: "wvlet-cli-{version}"
  runtime:
    path_addition:
      - "{root}/bin"
' >> .../extra_archives.yml
just install archives
tail -n 2 ~/.bashrc
[[ -d "/home/lchan/.local/share/ubuntu-dpm/wvlet/wvlet/bin" ]] && PATH=$PATH:/home/lchan/.local/share/ubuntu-dpm/wvlet/wvlet/bin
```



