### PR TITLE
feat!: add tenv to support terraform and opentofu

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,6 +153,37 @@ jobs:
         run: |
           just sdk tvm opentofu
           "$HOME/.local/bin/tofu" -version
+  test_tenv_install:
+    runs-on: ubuntu-latest
+    name: install-tenv
+    outputs:
+      result: ${{ steps.install.outcome || 'failure' }}
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - name: Install Just
+        uses: taiki-e/install-action@c6dc131d2c4291552cafb840290190a53b2cd937 # v2.44.67
+        with:
+          tool: just@${{ env.JUST_VERSION }}
+      - name: Test bootstrap
+        id: test-bootstrap
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          sudo apt -y -qq update
+          sudo apt install -y -qq libarchive-tools
+          just install archives
+          echo "$HOME/.local/share/ubuntu-dpm/tofuutils/tenv" >> "$GITHUB_PATH"
+      - name: Test Install
+        id: install
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          just sdk tvm tenv
+          tofu -version
+          terraform -version
   test_rvm_install:
     runs-on: ubuntu-latest
     name: install-rvm
@@ -260,7 +291,7 @@ jobs:
           just sdk sonar-scanner
       - name: Test Command
         run: |
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           sonar-scanner --version
   test_status:
     name: Assert Tests Passed
@@ -272,6 +303,7 @@ jobs:
       - test_nvm_install
       - test_tfenv_install
       - test_tofuenv_install
+      - test_tenv_install
       - test_rvm_install
       - test_sdkman_install
       - test_goenv_install
@@ -308,6 +340,7 @@ jobs:
             "${{ needs.test_goenv_install.outputs.result || 'failure'}}" \
             "${{ needs.test_pyenv_install.outputs.result || 'failure'}}" \
             "${{ needs.test_sonar_scanner_install.outputs.result || 'failure'}}" \
+            "${{ needs.test_tenv_install.outputs.result || 'failure'}}" \
             "${{ needs.test_tool_install.outputs.result || 'failure'}}";
           then
             echo "test_status=:thumbsup:" >> "$GITHUB_OUTPUT"
@@ -329,6 +362,7 @@ jobs:
       - test_nvm_install
       - test_tfenv_install
       - test_tofuenv_install
+      - test_tenv_install
       - test_rvm_install
       - test_sdkman_install
       - test_goenv_install

--- a/config/archives.yml
+++ b/config/archives.yml
@@ -35,3 +35,13 @@ parquet-cli-wrapper:
   runtime:
     path_addition:
       - "{root}"
+tenv:
+  repo: tofuutils/tenv
+  version:
+    github_tag: v3.2.10
+    strip_prefix: v
+  artifact: "tenv_{tag}_Linux_x86_64.tar.gz"
+  extract: ""
+  runtime:
+    path_addition:
+      - "{root}"

--- a/src/main/scripts/includes/sdk_install_all
+++ b/src/main/scripts/includes/sdk_install_all
@@ -6,6 +6,5 @@ sdk_install_all() {
   sdk_install_java
   sdk_install_pyenv "install"
   sdk_install_goenv "install"
-  sdk_install_tvm "opentofu"
   sdk_install_aws "update"
 }

--- a/src/main/scripts/includes/sdk_install_help
+++ b/src/main/scripts/includes/sdk_install_help
@@ -25,8 +25,9 @@ Some things have additional paramters as listed here
   install|latest      : Install it (goenv or pyenv)
   update              : Update the git repo that provides it
 'tvm'
-  terraform|tf        : install hashicorp/terraform
-  opentofu|tofu       : Install opentofu
+  terraform|tf        : install hashicorp/terraform via tfenv
+  opentofu|tofu       : Install opentofu via tofuenv
+  tenv                : install hashicorp/terraform and opentofu via tenv
 'java'
   install             : install baseline java tools (java/gradle/maven/jbang)
                         For backwards compatibility, this is the default behaviour.

--- a/src/main/scripts/includes/sdk_install_help
+++ b/src/main/scripts/includes/sdk_install_help
@@ -4,7 +4,7 @@ sdk_install_help() {
   cat <<EOF
 
 Usage: just sdk [$ACTION_LIST] [params]
-  all            Install rust, nvm, sdkman, python, goenv, tofu, aws.
+  all            Install rust, nvm, sdkman, python, goenv, aws.
   aws            Install/Update aws-cli
   goenv          Install/Update go-nv/goenv to manage golang
   help           Show help for sdk subcommand
@@ -28,6 +28,8 @@ Some things have additional paramters as listed here
   terraform|tf        : install hashicorp/terraform via tfenv
   opentofu|tofu       : Install opentofu via tofuenv
   tenv                : install hashicorp/terraform and opentofu via tenv
+                        Since tenv also supports atmos and terragrunt this is
+                        probably preferred.
 'java'
   install             : install baseline java tools (java/gradle/maven/jbang)
                         For backwards compatibility, this is the default behaviour.

--- a/src/main/scripts/includes/sdk_install_tvm
+++ b/src/main/scripts/includes/sdk_install_tvm
@@ -1,12 +1,23 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
+#shellcheck disable=SC2002
+__configure_tenv() {
+  tf_v=$(cat "$SDK_CONFIG" | yq -r ".terraform.version")
+  tofu_v=$(cat "$SDK_CONFIG" | yq -r ".opentofu.version")
+  tenv terraform install "$tf_v"
+  tenv terraform use "$tf_v"
+  tenv tofu install "$tofu_v"
+  tenv tofu use "$tofu_v"
+}
+
 sdk_install_tvm() {
   local tfenv_base=""
   local tfenv_github=""
   local tfenv_yamlpath=""
   local tfenv_bin=""
   local tf_v
+  local legacy_tvm="false"
 
   case "$1" in
   terraform | tf)
@@ -14,31 +25,44 @@ sdk_install_tvm() {
     tfenv_github="https://github.com/tfutils/tfenv"
     tfenv_yamlpath=".terraform.version"
     tfenv_bin="tfenv"
+    legacy_tvm="true"
     ;;
   opentofu | tofu)
     tfenv_base=".tofuenv"
     tfenv_github="https://github.com/tofuutils/tofuenv"
     tfenv_yamlpath=".opentofu.version"
     tfenv_bin="tofuenv"
+    legacy_tvm="true"
+    ;;
+  tenv)
+    if which tenv >/dev/null; then
+      __configure_tenv
+    else
+      echo -e "\n>>> Install tenv via 'just install archives' first"
+      exit 2
+    fi
     ;;
   *)
     echo "Unknown variant: $1"
     sdk_install_help
-    exit 1
+    exit 2
     ;;
   esac
 
-  if [[ -d "$HOME/$tfenv_base" ]]; then
-    echo "$1 env manager already installed"
-    (cd "$HOME/$tfenv_base" && git pull --rebase)
-  else
-    mkdir -p "$LOCAL_BIN"
-    (cd "$HOME" && git clone "$tfenv_github" "$tfenv_base")
-    #shellcheck disable=SC1083
-    ln -s "$HOME/$tfenv_base/bin"/* "$LOCAL_BIN"
+  if [[ "$legacy_tvm" == "true" ]]; then
+    echo -e "\n>>> Legacy terraform env manager '$1'"
+    if [[ -d "$HOME/$tfenv_base" ]]; then
+      echo "$1 env manager already installed"
+      (cd "$HOME/$tfenv_base" && git pull --rebase)
+    else
+      mkdir -p "$LOCAL_BIN"
+      (cd "$HOME" && git clone "$tfenv_github" "$tfenv_base")
+      #shellcheck disable=SC1083
+      ln -s "$HOME/$tfenv_base/bin"/* "$LOCAL_BIN"
+    fi
+    #shellcheck disable=SC2002
+    tf_v=$(cat "$SDK_CONFIG" | yq -r "$tfenv_yamlpath")
+    "$HOME/$tfenv_base/bin/$tfenv_bin" install "$tf_v"
+    "$HOME/$tfenv_base/bin/$tfenv_bin" use "$tf_v"
   fi
-  #shellcheck disable=SC2002
-  tf_v=$(cat "$SDK_CONFIG" | yq -r "$tfenv_yamlpath")
-  "$HOME/$tfenv_base/bin/$tfenv_bin" install "$tf_v"
-  "$HOME/$tfenv_base/bin/$tfenv_bin" use "$tf_v"
 }


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->
Well, why install install 2 managers, when you can just install one; now that we can install an archive and edit the path (which we couldn't before with gh-release-install) we can just install
the tar.gz of tenv and use it.

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- add tenv as an install via 'archives'
- add just sdk tvm tenv

BREAKING-CHANGE: tofuenv is no longer installed as part of 'just sdk all'
<!-- SQUASH_MERGE_END -->

## Testing

```console
rm -rf ~/.tfenv
rm -rf ~/.tofuenv
rm -f ~/.local/bin/terraform ~/.local/bin/tofu ~/.local/bin/tofuenv ~/.local/bin/tfenv
just install archives
which tenv  # might need to restart your shell / source .bashrc
just sdk tvm tenv
# At this point terraform & tofu are both available.
```


