### PR TITLE
refactor(pyenv): add build-essential for pyenv

### DIFF
--- a/src/main/scripts/includes/sdk_install_help
+++ b/src/main/scripts/includes/sdk_install_help
@@ -21,8 +21,12 @@ Some things have additional paramters as listed here
   install             : Install the AWS CLI
   update|upgrade      : Update the AWS CLI
   uninstall|rm         : Remove the AWS CLI (but not ~/.aws)
-'goenv' | 'pyenv'
-  install|latest      : Install it (goenv or pyenv)
+'goenv'
+  install|latest      : Install goenv itself and golang
+  update              : Update the git repo that provides it
+'pyenv'
+  install|latest      : Install pyenv itself and a python
+  prepare             : Install the sane dev environment as recommended by pyenv
   update              : Update the git repo that provides it
 'tvm'
   terraform|tf        : install hashicorp/terraform via tfenv

--- a/src/main/scripts/includes/sdk_install_pyenv
+++ b/src/main/scripts/includes/sdk_install_pyenv
@@ -26,6 +26,15 @@ sdk_install_pyenv() {
       fi
     fi
     python_v=$(cat "$SDK_CONFIG" | yq -r ".python.version")
+    # g++ is part of build-essential which should provide enough of a C compiler for us to do it.
+    if ! builtin command -v g++ >/dev/null; then
+      echo ">>> No C compiler, so lets install one"
+      # Install all the things from https://github.com/pyenv/pyenv/wiki#suggested-build-environment
+      # not getting tk-dev because of all the X11 things.
+      sudo apt -y install build-essential libssl-dev zlib1g-dev \
+        libbz2-dev libreadline-dev libsqlite3-dev \
+        libncursesw5-dev xz-utils libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
+    fi
     "$PYENV_ROOT/bin/pyenv" install -s "$python_v"
     "$PYENV_ROOT/bin/pyenv" global "$python_v"
     "$PYENV_ROOT/bin/pyenv" versions

--- a/src/main/scripts/includes/sdk_install_pyenv
+++ b/src/main/scripts/includes/sdk_install_pyenv
@@ -3,6 +3,14 @@
 # shellcheck disable=SC2002
 set -eo pipefail
 
+# Install all the things from https://github.com/pyenv/pyenv/wiki#suggested-build-environment
+# including tk-dev even though that means all the X11 things.
+__pyenv_prepare() {
+  sudo apt -y install build-essential libssl-dev zlib1g-dev \
+    libbz2-dev libreadline-dev libsqlite3-dev \
+    libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
+}
+
 sdk_install_pyenv() {
   rm -f "$LOCAL_BIN/pyenv"
   if [[ -d "$PYENV_ROOT" ]]; then
@@ -26,18 +34,18 @@ sdk_install_pyenv() {
       fi
     fi
     python_v=$(cat "$SDK_CONFIG" | yq -r ".python.version")
-    # g++ is part of build-essential which should provide enough of a C compiler for us to do it.
+    # g++ is part of build-essential which provides c++ compiler
+    # gcc would what provides a C compiler this could effectively
+    # be a check if ! sudo apt list --installed | grep build-essential; then
     if ! builtin command -v g++ >/dev/null; then
-      echo ">>> No C compiler, so lets install one"
-      # Install all the things from https://github.com/pyenv/pyenv/wiki#suggested-build-environment
-      # not getting tk-dev because of all the X11 things.
-      sudo apt -y install build-essential libssl-dev zlib1g-dev \
-        libbz2-dev libreadline-dev libsqlite3-dev \
-        libncursesw5-dev xz-utils libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
+      __pyenv_prepare
     fi
     "$PYENV_ROOT/bin/pyenv" install -s "$python_v"
     "$PYENV_ROOT/bin/pyenv" global "$python_v"
     "$PYENV_ROOT/bin/pyenv" versions
+    ;;
+  prepare)
+    __pyenv_prepare
     ;;
   *)
     echo ">>> pyenv updated"


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->
On a new debian instance trying to install pyenv; it failed because of a missing C compiler...

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- add check for build-essential and install if not
- add explicit prepare subcommand 'sdk pyenv prepare'
<!-- SQUASH_MERGE_END -->

## Testing

> Could do an `apt list --installed | grep ` and check exit code but I'm not sure what to grep for since it's a lot of packages; and we don't want to install them if we don't care about python?

```
sudo apt remove g++
sudo apt autoremove
pyenv remove 3.12.7 (if you have it)
just sdk pyenv install
```
