### PR TITLE
refactor(java)!: switch default JDK from graalvm to corretto

### DIFF
--- a/config/sdk.yml
+++ b/config/sdk.yml
@@ -7,7 +7,7 @@ terraform:
 opentofu:
   version: 1.8.8
 sdkman:
-  java: 21.0.2-graalce
+  java: 21.0.5-amzn
   gradle: 8.10.2
   maven: 3.9.9
   jbang: 0.122.0

--- a/src/main/scripts/includes/sdk_install_java
+++ b/src/main/scripts/includes/sdk_install_java
@@ -33,7 +33,7 @@ __sdkman_interactive_mode() {
 
 __sdkman_base() {
   local sdkman_mode
-  local graal_v
+  local java_v
   local maven_v
   local jbang_v
   local gradle_v
@@ -53,16 +53,16 @@ __sdkman_base() {
   #shellcheck disable=SC1090
   source ~/.sdkman/bin/sdkman-init.sh
 
-  graal_v=$(cat "$SDK_CONFIG" | yq -r ".sdkman.java")
+  java_v=$(cat "$SDK_CONFIG" | yq -r ".sdkman.java")
   maven_v=$(cat "$SDK_CONFIG" | yq -r ".sdkman.maven")
   jbang_v=$(cat "$SDK_CONFIG" | yq -r ".sdkman.jbang")
   gradle_v=$(cat "$SDK_CONFIG" | yq -r ".sdkman.gradle")
 
-  sdk install java "$graal_v"
+  sdk install java "$java_v"
   sdk install gradle "$gradle_v"
   sdk install maven "$maven_v"
   sdk install jbang "$jbang_v"
-  echo "[+] GraalVM=$graal_v, Gradle=$gradle_v, Maven=$maven_v, jbang=$jbang_v"
+  echo "[+] Java=$java_v, Gradle=$gradle_v, Maven=$maven_v, jbang=$jbang_v"
   __sdkman_interactive_mode "$sdkman_mode"
 }
 

--- a/updatecli.d/sdk-java.yml
+++ b/updatecli.d/sdk-java.yml
@@ -1,0 +1,60 @@
+# {{ $scmEnabled := and (env "GITHUB_REPOSITORY_OWNER") (env "GITHUB_REPOSITORY_NAME") }}
+name: "java/corretto"
+version: 0.91.0
+
+# {{ if $scmEnabled }}
+actions:
+  pull_request:
+    scmid: github
+    title: 'chore(deps): Bump java/corretto version to {{ source "latest" }}-amzn'
+    kind: github/pullrequest
+    spec:
+      labels:
+        - dependencies
+
+scms:
+  github:
+    disabled: false
+    kind: github
+    spec:
+      branch: main
+      owner: '{{ requiredEnv "GITHUB_REPOSITORY_OWNER" }}'
+      repository: '{{ requiredEnv "GITHUB_REPOSITORY_NAME" }}'
+      user: '{{ requiredEnv "UPDATECLI_GITHUB_USER" }}'
+      email: '{{ requiredEnv "UPDATECLI_GITHUB_EMAIL" }}'
+      username: '{{ requiredEnv "UPDATECLI_GITHUB_USER" }}'
+      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+      commitmessage:
+        type: "chore"
+        scope: "deps"
+        title: 'Bump java/corretto version to {{ source "latest" }}-amzn'
+        hidecredit: true
+# {{ end }}
+
+sources:
+  latest:
+    name: Github release for java/corretto
+    kind: githubrelease
+    spec:
+      owner: corretto
+      repository: corretto-21
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      # comes through as 21.0.5.11.1 or similar so we need to strip out the .11.1 before
+      # semver-ing.
+      versionfilter:
+        kind: regex/semver
+        regex: "^(\\d*\\.\\d*\\.\\d*).*$"
+
+targets:
+  update_yaml:
+    kind: yaml
+    sourceid: latest
+    name: 'Bump java/corretto version to {{ source "latest" }}-amzn'
+    # {{ if $scmEnabled }}
+    scmid: github
+    # {{ end }}
+    spec:
+      files:
+        - ./config/sdk.yml
+      key: $.sdkman.java
+      value: '{{ source "latest" }}-amzn'


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->
graalvm-ce 21.0.2 will never be updated (since graalvm-ce is the community edition) which means we are potentially missing out on the fixes for 0.3 / 0.4 / 0.5

We want a jdk that is
- available via sdkman
- marked as a github release, so that we can updatecli it
- (stops us from having to triage non LTS releases since I don't want to run JDK23+ until JDK25 is available).

so the options were

- temurin: https://github.com/adoptium/temurin21-binaries for temurin (`jdk-(\\d*\\.\\d*\\.\\d*).*$`)
- corretto: https://github.com/corretto/corretto-21 (`^(\\d*\\.\\d*\\.\\d*).*$`)
- liberica: https://github.com/bell-sw/Liberica (`^(\\d*\\.\\d*\\.\\d*).*$`) but the repo has all the java versions.
- mandrel doesn't really follow the same LTS naming cycle
- zulu java doesn't have a github project (this would be what I would traditionally have used)

So, why not corretto.

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- switch to 21.0.5-amzn
- add updatecli config for corretto/corretto-21
<!-- SQUASH_MERGE_END -->

## Notes

- Note that I used regex/semver even though vscode hates it (the vscode schema hasn't been updated).
- On the other hand, using `ghcr.io/bell-sw/liberica-runtime-container:jre-21-slim-musl` as a baseline docker image might be amusing.
