### PR TITLE
fix(updatecli): add transformer for java/correto to strip extended version

### DIFF
--- a/updatecli.d/sdk-java.yml
+++ b/updatecli.d/sdk-java.yml
@@ -1,6 +1,6 @@
 # {{ $scmEnabled := and (env "GITHUB_REPOSITORY_OWNER") (env "GITHUB_REPOSITORY_NAME") }}
 name: "java/corretto"
-version: 0.91.0
+version: 0.92.0
 
 # {{ if $scmEnabled }}
 actions:
@@ -44,6 +44,10 @@ sources:
       versionfilter:
         kind: regex/semver
         regex: "^(\\d*\\.\\d*\\.\\d*).*$"
+    transformers:
+      - findsubmatch:
+          pattern: "^(\\d*\\.\\d*\\.\\d*).*$"
+          captureindex: 1
 
 targets:
   update_yaml:


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->
Because updatecli change the semantics of regex/semver

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- add findsubmatch transformer to strip extended versioning
<!-- SQUASH_MERGE_END -->


