### PR TITLE
refactor: add explicit desktop bootstrap

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -55,6 +55,7 @@ updatecli type='personal' +args='diff':
 @apt_update:
   sudo apt -y update
   sudo apt -y upgrade
+  sudo apt -y autoremove
 
 [private]
 [no-cd]


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->
Really should switch to using the Microsoft APT repo to install vscode on my linux laptop.

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- add explicit bootstrap.sh desktop
- add autoremove post apt upgrade
<!-- SQUASH_MERGE_END -->

