### PR TITLE
refactor!: remove jsonschema2pojo

### DIFF
--- a/config/archives.yml
+++ b/config/archives.yml
@@ -17,19 +17,6 @@
 # Note that 'extract' -> awk -F'/' '{print NF}' for a --strip-components, so it potentially
 # doesn't matter what you put in here, since it just becomes a number, just need the
 # right number of /...
-jsonschema2pojo:
-  repo: joelittlejohn/jsonschema2pojo
-  version:
-    github_tag: jsonschema2pojo-1.2.2
-    strip_prefix: jsonschema2pojo-
-  artifact: "jsonschema2pojo-{version}.zip"
-  extract: "{tag}"
-  runtime:
-    symlinks:
-      - "{root}/bin/jsonschema2pojo"
-  updatecli:
-    kind: regex
-    pattern: 'jsonschema2pojo-[0-9]+\\.[0-9]+\\.[0-9]+$'
 qsv:
   repo: dathere/qsv
   version:
@@ -38,14 +25,16 @@ qsv:
   runtime:
     path_addition:
       - "{root}"
+  updatecli:
+    kind: semver
 parquet-cli-wrapper:
   repo: quotidian-ennui/parquet-cli-wrapper
   version:
     github_tag: 1.15.2
   artifact: "parquet-cli.tar.gz"
   runtime:
-    path_addition:
-      - "{root}"
+    symlinks:
+      - "{root}/parquet"
 tenv:
   repo: tofuutils/tenv
   version:


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->
- don't use jsonschema2pojo so remove it

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- remove jsonschema2pojo
- make parquet-cli a symlink
<!-- SQUASH_MERGE_END -->

## Testing

> There is no uninstall so we have to manually fudge it so that we test as though we were new.

- remove parquet cli from the path (~/.bashrc) if it's in there.
- remove jsonschema2pojo symlink from ~/.local/bin
- remove jsonschema2pojo from ~/.local/share/ubuntu-dpm
- edit ~/.config/ubuntu-dpm/installed-versions to remove parquet-cli
- just install archives -> no jsonschema2pop, but new symlink for parquet
