### PR TITLE
Fix/trixie bootstrap

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,7 +5,7 @@
 
 set -eo pipefail
 
-PRE_REQ_TOOLS="apt-transport-https ca-certificates curl gnupg wget software-properties-common"
+PRE_REQ_TOOLS="apt-transport-https ca-certificates curl gnupg wget lsb-release make man-db"
 DOCKER_TOOL_LIST="docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin"
 BASELINE_TOOL_LIST="vim nfs-common unison direnv git zoxide jq tidy kubectl helm gh jq pipx trivy net-tools zip unzip libarchive-tools"
 JOB_SUMMARY=""

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -188,10 +188,6 @@ action_baseline() {
   # shellcheck disable=SC2086
   sudo apt install -y $BASELINE_TOOL_LIST
   pipx install gh-release-install
-  if ! which just >/dev/null 2>&1; then
-    # Oneshot install that we know works for us.
-    "$HOME/.local/bin/gh-release-install" "casey/just" "just-1.40.0-x86_64-unknown-linux-musl.tar.gz" "$HOME/.local/bin/just" --version "1.40.0" --extract just
-  fi
   install_vscode "$distro_name"
   install_docker "$distro_name"
   if [[ -n "$WSL_DISTRO_NAME" ]]; then
@@ -212,6 +208,11 @@ action_baseline() {
   if [[ "$distro_name" == "debian" ]]; then
     sudo apt install -y bsdextrautils
   fi
+  # Oneshot install that we know works for us.
+  "$HOME/.local/bin/gh-release-install" "casey/just" "just-1.40.0-x86_64-unknown-linux-musl.tar.gz" "$HOME/.local/bin/just.bootstrap" --version "1.40.0" --extract just
+  "$HOME/.local/bin/just.bootstrap" init
+  "$HOME/.local/bin/just.bootstrap" tools
+  rm -f "$HOME/.local/bin/just.bootstrap"
 }
 
 distro_name() {

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -54,13 +54,19 @@ repo_trivy() {
   download_keyrings "https://aquasecurity.github.io/trivy-repo/deb/public.key" "trivy"
   local trivy_fallback=""
   local current_release=""
+  local current_version=""
   current_release=$(lsb_release -sc)
   if [[ "$1" == "ubuntu" ]]; then
     # focal -> jammy -> noble
     trivy_fallback="jammy"
   else
-    # buster -> bullseye -> bookworm
-    trivy_fallback="bullseye"
+    # buster -> bullseye -> bookworm -> trixie
+    current_version=$(lsb_release -sr)
+    case "$current_version" in
+    12) trivy_fallback="bullseye";;
+    13) trivy_fallback="bookworm";;
+    *)  trivy_fallback="buster";;
+    esac
   fi
   local repo_name="$current_release"
   if ! curl -fsSL "https://raw.githubusercontent.com/aquasecurity/trivy-repo/main/deb/dists/$current_release/Release" >/dev/null 2>&1; then

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -63,9 +63,9 @@ repo_trivy() {
     # buster -> bullseye -> bookworm -> trixie
     current_version=$(lsb_release -sr)
     case "$current_version" in
-    12) trivy_fallback="bullseye";;
-    13) trivy_fallback="bookworm";;
-    *)  trivy_fallback="buster";;
+    12) trivy_fallback="bullseye" ;;
+    13) trivy_fallback="bookworm" ;;
+    *) trivy_fallback="buster" ;;
     esac
   fi
   local repo_name="$current_release"
@@ -178,6 +178,7 @@ action_repos() {
   repo_docker "$distro_name"
   repo_trivy "$distro_name"
   if [[ "$distro_name" == "ubuntu" ]]; then
+    sudo apt install -y software-properties-common
     sudo add-apt-repository -y ppa:git-core/ppa
   fi
   sudo apt update

--- a/src/main/scripts/includes/init_direnv
+++ b/src/main/scripts/includes/init_direnv
@@ -3,6 +3,5 @@
 set -eo pipefail
 
 init_direnv() {
-  mkdir -p ~/.config/direnv && wget -q -O ~/.config/direnv/direnvrc https://raw.githubusercontent.com/direnv/direnv/master/stdlib.sh
   mkdir -p ~/.local/share/direnv/allow
 }

--- a/src/main/scripts/init.sh
+++ b/src/main/scripts/init.sh
@@ -7,7 +7,7 @@ source "$BASEDIR/common.sh"
 ACTION_LIST=()
 
 source_actions() {
-  for f in "$BASEDIR"/includes/init_*; do
+  find -L "$BASEDIR/includes" -type f -name "init_*" -print0 | while read -d $'\0' -r f; do
     #shellcheck disable=SC1090
     source "$f"
     name=$(basename "$f")


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->
- resolves #808 
- resolves #803 
- resolves #804

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- push software-properties-common into ubuntu only
- remove direnv stdlib
- directly execute just tools in 'baseline'
- add trixie fallback to bookworm for trivy

<!-- SQUASH_MERGE_END -->

## Testing

Tested on WSL2 (so no testing of vscode installs etc) and we start off in powershell

### Debian Trixie

```console
wsl.exe --install Debian --name Debian-13
# Because for testing, I'm super lazy
echo "$USER ALL=(ALL:ALL) NOPASSWD:ALL" | sudo tee -a /etc/sudoers.d/lenient
mkdir -p ~/.local/bin && export PATH=$HOME/.local/bin:$PATH
sudo apt install -y git
cd ubuntu-dpm
./bootstrap.sh repos
./bootstrap.sh baseline
```

- docker is installed
- the default tools are installed (so just 1.42.4 instead of 1.40)

### Ubuntu

```console
wsl.exe --install Ubuntu-24.04 --name Ubuntu-Fresh
mkdir -p ~/.local/bin && export PATH=$HOME/.local/bin:$PATH
echo "$USER ALL=(ALL:ALL) NOPASSWD:ALL" | sudo tee -a /etc/sudoers.d/lenient
sudo apt install -y git
git clone -b fix/trixie-bootstrap https://github.com/quotidian-ennui/ubuntu-dpm
cd ubuntu-dpm
./bootstrap.sh repos
./bootstrap.sh baseline
```

- docker is installed
- the default tools are installed (so just 1.42.4 instead of 1.40)
