### PR TITLE
feat: support regex/semver in updatecli template

### DIFF
--- a/src/main/resources/archive-updatecli.yml
+++ b/src/main/resources/archive-updatecli.yml
@@ -42,6 +42,9 @@ sources:
       versionfilter:
         kind: "{{ .kind }}"
         pattern: "{{ .pattern }}"
+        # {{ if .regex }}
+        regex: "{{ .regex }}"
+        # {{ end }}
     # {{ if .trim_prefix }}
     transformers:
       - trimprefix: "{{ .trim_prefix }}"

--- a/src/main/resources/local-archive-updatecli.yml
+++ b/src/main/resources/local-archive-updatecli.yml
@@ -11,6 +11,9 @@ sources:
       versionfilter:
         kind: "{{ .kind }}"
         pattern: "{{ .pattern }}"
+        # {{ if .regex }}
+        regex: "{{ .regex }}"
+        # {{ end }}
     # {{ if .trim_prefix }}
     transformers:
       - trimprefix: "{{ .trim_prefix }}"

--- a/src/main/resources/local-updatecli.yml
+++ b/src/main/resources/local-updatecli.yml
@@ -11,6 +11,9 @@ sources:
       versionfilter:
         kind: "{{ .kind }}"
         pattern: "{{ .pattern }}"
+        # {{ if .regex }}
+        regex: "{{ .regex }}"
+        # {{ end }}
     # {{ if .trim_prefix }}
     transformers:
       - trimprefix: "{{ .trim_prefix }}"

--- a/src/main/resources/updatecli.yml
+++ b/src/main/resources/updatecli.yml
@@ -42,6 +42,9 @@ sources:
       versionfilter:
         kind: "{{ .kind }}"
         pattern: "{{ .pattern }}"
+        # {{ if .regex }}
+        regex: "{{ .regex }}"
+        # {{ end }}
     # {{ if .trim_prefix }}
     transformers:
       - trimprefix: "{{ .trim_prefix }}"

--- a/src/main/scripts/updatecli.sh
+++ b/src/main/scripts/updatecli.sh
@@ -12,6 +12,7 @@ TOOL_JQ_FILTER='
       "yamlpath": (if .value.updatecli.yamlpath == null then "$.\(.key).version" else .value.updatecli.yamlpath end),
       "pattern": (if .value.updatecli.pattern == null then "*" else .value.updatecli.pattern end),
       "kind": (if .value.updatecli.kind == null then "semver" else .value.updatecli.kind end),
+      "regex": .value.updatecli.regex,
       "trim_prefix": .value.updatecli.trim_prefix
     }
     | with_entries(if .value == null then empty else . end)
@@ -24,6 +25,7 @@ ARCHIVE_JQ_FILTER='
       "yamlpath": (if .value.updatecli.yamlpath == null then "$.\(.key).version.github_tag" else .value.updatecli.yamlpath end),
       "pattern": (if .value.updatecli.pattern == null then "*" else .value.updatecli.pattern end),
       "kind": (if .value.updatecli.kind == null then "semver" else .value.updatecli.kind end),
+      "regex": .value.updatecli.regex,
       "trim_prefix": .value.version.strip_prefix
     }
     | with_entries(if .value == null then empty else . end)


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->
I would like to be able to set the `regex` part of a version filter for the kind [`regex/semver`](https://www.updatecli.io/docs/core/versionfilter/#_regexsemver)

```yaml
xidel:
  repo: benibela/xidel
  version: Xidel_0.9.8
  artifact: xidel-0.9.8.linux64.tar.gz
  contents: xidel
  updatecli:
    kind: regex/semver
    pattern: "*"
    regex: Xidel_(\\d*\\.\\d*\\.\\d*)
```

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- add regex to versionfilter templates
- update updatecli script to set regex when available
<!-- SQUASH_MERGE_END -->

## Testing

Add the snippet above to yours optional tools:

```shell
just updatecli personal diff
```

