### PR TITLE
chore(ghcli): disable telemetry by default

### DIFF
--- a/src/main/scripts/configure_ghcli.sh
+++ b/src/main/scripts/configure_ghcli.sh
@@ -9,3 +9,4 @@ gh extension install quotidian-ennui/gh-rate-limit || true
 gh extension install quotidian-ennui/gh-squash-merge || true
 gh extension install quotidian-ennui/gh-approve-deploy || true
 gh extension install quotidian-ennui/gh-merge-train || true
+gh config set telemetry disabled


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->
Because _really_ in an ideal situation all telemetry should be opt-in not opt-out; but we are where we are.

Let's disable ghcli by default when bootstrapping (so when I install a new WSL/U-26.04) so we can choose to opt in.

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- gh config set telemetry disabled

<!-- SQUASH_MERGE_END -->

## Notes

I _already had_ DO_NOT_TRACK set to true, so this actually would have had no effect for me.