### PR TITLE
feat: add post_install step

### DIFF
--- a/src/main/scripts/includes/install_tools
+++ b/src/main/scripts/includes/install_tools
@@ -9,6 +9,14 @@
 # and then do the wsl --shutdown restart dance.
 set -eo pipefail
 
+__post_install_step() {
+  local cmd="$1"
+  local file="$2"
+  pushd "$LOCAL_BIN" >/dev/null
+  eval "$cmd $file"
+  popd >/dev/null
+}
+
 install_tools() {
   local files=("$TOOL_CONFIG")
   local tools
@@ -24,13 +32,14 @@ install_tools() {
     files+=("$DPM_TOOLS_ADDITIONS_YAML")
   fi
   # shellcheck disable=SC2016
-  tools=$(yq_wrapper -p yaml -o json eval-all '. as $item ireduce ({}; . *+ $item)' "${files[@]}" | jq -c ".[]")
+  mapfile -t tools < <(yq_wrapper -p yaml -o json eval-all '. as $item ireduce ({}; . *+ $item)' "${files[@]}" | jq -c ".[]")
 
-  for line in $tools; do
-    repo=$(echo "$line" | jq -r ".repo")
-    version=$(echo "$line" | jq -r ".version")
-    artifact=$(echo "$line" | jq -r ".artifact")
-    contents_line=$(echo "$line" | jq -r ".contents")
+  for line in "${tools[@]}"; do
+    repo=$(echo "$line" | jq -r '.repo')
+    version=$(echo "$line" | jq -r '.version')
+    artifact=$(echo "$line" | jq -r '.artifact')
+    contents_line=$(echo "$line" | jq -r '.contents')
+    post_install=$(echo "$line" | jq -r 'select(.post_install != null) | .post_install')
     extract=$(echo "$contents_line" | cut -f1 -d':')
     binary=$(echo "$contents_line" | cut -f2 -d':')
     binary=${binary:-$extract}
@@ -45,6 +54,9 @@ install_tools() {
         # since extract_cmdline needs to be expanded.
         # shellcheck disable=SC2086
         gh_release_install "$repo" "$artifact" "$LOCAL_BIN/$binary" --version "$version" $extract_cmdline
+        if [[ "$post_install" != "" ]]; then
+          __post_install_step "$post_install" "$binary"
+        fi
         # shellcheck disable=SC2004
         installed[$binary]="$version"
       else


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->

Resolves #1218 (but not brilliantly).

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- add post_install step
- add protection for "spaces" in for loop

<!-- SQUASH_MERGE_END -->

## Testing
<!-- Testing Notes -->

It's fully backwards compatible so we can just do this, in this specific instance.

```yaml
restic:
  repo: restic/restic
  version: v0.18.1
  artifact: restic_{version}_linux_amd64.bz2
  contents: :restic.bz
  post_install: bunzip2 -fk
```

- The side effect is that it's registered as restic.bz2 in the 'installed-versions' file which is why the `-k` is there, so it keeps the restic.bz2 file, so we don't get continual attempts to install.

It is very dangerous so I probably wouldn't make this part of the main toolset; and I hate myself a little for using eval.
